### PR TITLE
query error logging length

### DIFF
--- a/error.go
+++ b/error.go
@@ -17,7 +17,7 @@ type Error struct {
 
 // QueryErrorLoggingLength is the size of the query
 // characters that are logged when an error occurs
-var QueryErrorLoggingLength = 1 << 11 // 2kB
+var QueryErrorLoggingLength = 1 << 12 // 4kB
 
 func (v Error) Error() string {
 	if len(v.ReplacedQuery) > QueryErrorLoggingLength {

--- a/error.go
+++ b/error.go
@@ -15,6 +15,14 @@ type Error struct {
 	Params        Params
 }
 
+// QueryErrorLoggingLength is the size of the query
+// characters that are logged when an error occurs
+var QueryErrorLoggingLength = 1 << 11 // 2kB
+
 func (v Error) Error() string {
+	if len(v.ReplacedQuery) > QueryErrorLoggingLength {
+		half := QueryErrorLoggingLength >> 1
+		v.ReplacedQuery = v.ReplacedQuery[:half] + fmt.Sprintf("\n/* %d characters hidden */\n", len(v.ReplacedQuery)-QueryErrorLoggingLength) + v.ReplacedQuery[len(v.ReplacedQuery)-half:]
+	}
 	return fmt.Sprintf("%s\n\nquery len:\n%d\n\nquery:\n%s\n\nparams:\n%s", v.Err.Error(), len(v.ReplacedQuery), v.ReplacedQuery, spew.Sdump(v.Params))
 }


### PR DESCRIPTION
Created a variable that shrinks the query character length down to a specified amount (2kB by default)