### PR TITLE
Fix typo in Params comment

### DIFF
--- a/params.go
+++ b/params.go
@@ -17,7 +17,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// Params are a map of paramterer names to values
+// Params are a map of parameter names to values
 // use in the query like `select @@Name`
 type Params map[string]any
 


### PR DESCRIPTION
## Summary
- fix a minor typo in the comment describing `Params`

## Testing
- `go test ./...` *(fails: Go toolchain requires network)*

------
https://chatgpt.com/codex/tasks/task_e_683f3de5eb74832fad7a97d8e7dcb8c6