### PR TITLE
Fix param replacement adjacent to alias

### DIFF
--- a/params.go
+++ b/params.go
@@ -132,7 +132,7 @@ func interpolateParams(query string, tmplFuncs template.FuncMap, valuerFuncs map
 	defer stringsBuilderPool.Put(s)
 	s.Reset()
 
-	for _, t := range queryTokens {
+	for i, t := range queryTokens {
 		switch t.kind {
 		case queryTokenKindParam:
 			k := strings.ToLower(t.string[2:])
@@ -149,6 +149,16 @@ func interpolateParams(query string, tmplFuncs template.FuncMap, valuerFuncs map
 				}
 
 				s.Write(b)
+
+				if next := i + 1; next < len(queryTokens) {
+					nt := queryTokens[next]
+					if nt.pos == t.end+1 {
+						switch nt.kind {
+						case queryTokenKindString, queryTokenKindWord, queryTokenKindVar, queryTokenKindParam:
+							s.WriteByte(' ')
+						}
+					}
+				}
 
 				usedParams[k] = struct{}{}
 				break

--- a/params_test.go
+++ b/params_test.go
@@ -207,6 +207,15 @@ func TestInterpolateParams(t *testing.T) {
 			wantReplacedQuery:    "SELECT * FROM `test` WHERE `hello` = ''",
 			wantNormalizedParams: Params{"world": ""},
 		},
+		{
+			name: "param touching alias",
+			args: args{
+				query:  "SELECT @@foo`bar`",
+				params: []any{Params{"foo": 1}},
+			},
+			wantReplacedQuery:    "SELECT 1 `bar`",
+			wantNormalizedParams: Params{"foo": 1},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fix https://github.com/StirlingMarketingGroup/cool-mysql/issues/3

## Summary
- ensure InterpolateParams adds a space when a replaced parameter is followed immediately by an identifier or string
- cover this case with a new unit test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f60aea308832f9e0b03bb7abf5983