### PR TITLE
Add pluggable logger with slog default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **JSON columns** can unmarshal directly into struct fields
 - **Channels** supported for selecting and inserting
 - Optional **query logging** and transaction helpers
+- **Pluggable logging** using `log/slog` by default with a Zap adapter
 
 ## Installation
 

--- a/database.go
+++ b/database.go
@@ -18,8 +18,6 @@ import (
 	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
 	"github.com/go-sql-driver/mysql"
 	"github.com/redis/go-redis/v9"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // Database is a cool MySQL connection
@@ -46,7 +44,7 @@ type Database struct {
 
 	testMx *sync.Mutex
 
-	Logger                      *zap.Logger
+	Logger                      Logger
 	DisableUnusedColumnWarnings bool
 
 	tmplFuncs   template.FuncMap
@@ -190,13 +188,7 @@ func NewFromDSN(writes, reads string) (db *Database, err error) {
 		db.Reads = writesConn
 	}
 
-	config := zap.NewDevelopmentConfig()
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	l, err := config.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create logger: %w", err)
-	}
-	db.Logger = l.Named("cool-mysql")
+	db.Logger = DefaultLogger()
 
 	return
 }
@@ -233,13 +225,7 @@ func NewFromConn(writesConn, readsConn *sql.DB) (*Database, error) {
 	}
 
 	// 4) Logger setup (identical to NewFromDSN)
-	config := zap.NewDevelopmentConfig()
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	l, err := config.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create logger: %w", err)
-	}
-	db.Logger = l.Named("cool-mysql")
+	db.Logger = DefaultLogger()
 
 	return db, nil
 }
@@ -257,13 +243,7 @@ func NewLocalWriter(path string) (*Database, error) {
 	db.MaxInsertSize = new(synct[int])
 	db.MaxInsertSize.Set(1 << 20)
 
-	config := zap.NewDevelopmentConfig()
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	l, err := config.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create logger: %w", err)
-	}
-	db.Logger = l.Named("cool-mysql")
+	db.Logger = DefaultLogger()
 
 	return db, nil
 }
@@ -280,13 +260,7 @@ func NewWriter(w io.Writer) (*Database, error) {
 	db.MaxInsertSize = new(synct[int])
 	db.MaxInsertSize.Set(1 << 20)
 
-	config := zap.NewDevelopmentConfig()
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	l, err := config.Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create logger: %w", err)
-	}
-	db.Logger = l.Named("cool-mysql")
+	db.Logger = DefaultLogger()
 
 	return db, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,37 +1,37 @@
 module github.com/StirlingMarketingGroup/cool-mysql
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.2
 
 require (
-	cloud.google.com/go v0.115.1
-	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/fatih/structtag v1.2.0
-	github.com/go-redsync/redsync/v4 v4.8.1
-	github.com/go-sql-driver/mysql v1.7.1
-	github.com/redis/go-redis/v9 v9.0.4
-	github.com/shopspring/decimal v1.3.1
-	github.com/vmihailenco/msgpack/v5 v5.3.5
-	go.uber.org/zap v1.24.0
-	golang.org/x/crypto v0.35.0
-	golang.org/x/sync v0.8.0
+        cloud.google.com/go v0.115.1
+        github.com/cenkalti/backoff/v4 v4.2.1
+        github.com/fatih/structtag v1.2.0
+        github.com/go-redsync/redsync/v4 v4.8.1
+        github.com/go-sql-driver/mysql v1.7.1
+        github.com/redis/go-redis/v9 v9.0.4
+        github.com/shopspring/decimal v1.3.1
+        github.com/vmihailenco/msgpack/v5 v5.3.5
+        go.uber.org/zap v1.24.0
+        golang.org/x/crypto v0.35.0
+        golang.org/x/sync v0.8.0
 )
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/go-redis/redis/v8 v8.11.5 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
-	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sys v0.30.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+        github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
+        github.com/cespare/xxhash/v2 v2.2.0 // indirect
+        github.com/davecgh/go-spew v1.1.1 // indirect
+        github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+        github.com/go-redis/redis/v8 v8.11.5 // indirect
+        github.com/hashicorp/errwrap v1.1.0 // indirect
+        github.com/hashicorp/go-multierror v1.1.1 // indirect
+        github.com/pkg/errors v0.9.1 // indirect
+        github.com/pmezard/go-difflib v1.0.0 // indirect
+        github.com/stretchr/testify v1.10.0 // indirect
+        github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+        go.uber.org/atomic v1.11.0 // indirect
+        go.uber.org/multierr v1.11.0 // indirect
+        golang.org/x/sys v0.30.0 // indirect
+        gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,28 @@
+package mysql
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Logger defines the minimal logging interface used by this package.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+}
+
+// SlogLogger adapts slog.Logger to the Logger interface.
+type SlogLogger struct{ *slog.Logger }
+
+func (l SlogLogger) Debug(msg string, args ...any) { l.Logger.Debug(msg, args...) }
+func (l SlogLogger) Info(msg string, args ...any)  { l.Logger.Info(msg, args...) }
+func (l SlogLogger) Warn(msg string, args ...any)  { l.Logger.Warn(msg, args...) }
+func (l SlogLogger) Error(msg string, args ...any) { l.Logger.Error(msg, args...) }
+
+// DefaultLogger returns a slog-based logger used when none is provided.
+func DefaultLogger() Logger {
+	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return SlogLogger{slog.New(h).With("module", "cool-mysql")}
+}

--- a/zaplogger.go
+++ b/zaplogger.go
@@ -1,0 +1,11 @@
+package mysql
+
+import "go.uber.org/zap"
+
+// ZapLogger adapts zap.Logger to the Logger interface.
+type ZapLogger struct{ *zap.Logger }
+
+func (l ZapLogger) Debug(msg string, args ...any) { l.Logger.Sugar().Debugf(msg, args...) }
+func (l ZapLogger) Info(msg string, args ...any)  { l.Logger.Sugar().Infof(msg, args...) }
+func (l ZapLogger) Warn(msg string, args ...any)  { l.Logger.Sugar().Warnf(msg, args...) }
+func (l ZapLogger) Error(msg string, args ...any) { l.Logger.Sugar().Errorf(msg, args...) }


### PR DESCRIPTION
## Summary
- introduce a generic `Logger` interface with a slog implementation
- provide a Zap adapter for drop-in compatibility
- update `Database` to use the logger interface and default to slog
- bump `go` version to 1.24
- document logging flexibility in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f654dc960832f8f2bb91ad9fb99df