### PR TITLE
Implement pluggable caching system

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - **Dual pools** for reads and writes
 - **Named template parameters** using `@@name` tokens
 - **Automatic retries** with exponential backoff
-- **Redis backed caching** with optional distributed locks
+- **Pluggable caching** (Redis, Memcached, or in-memory weak pointers) with optional distributed locks
 - **Insert/Upsert helpers** that chunk large sets to respect `max_allowed_packet`
 - **Go template syntax** in queries for conditional logic
 - **Flexible selection** into structs, slices, maps, channels or functions
@@ -55,7 +55,7 @@ func main() {
     var users []User
     err = db.Select(&users,
         "SELECT id, name FROM users WHERE created_at > @@since",
-        time.Minute, // cache TTL when Redis is configured
+        time.Minute, // cache TTL when caching is configured
         mysql.Params{"since": time.Now().Add(-24 * time.Hour)},
     )
     if err != nil {
@@ -64,6 +64,23 @@ func main() {
 
     log.Printf("loaded %d users", len(users))
 }
+```
+
+### Enabling caching
+
+```go
+// use Redis
+r := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+db.EnableRedis(r)
+
+// or Memcached
+db.EnableMemcache(memcache.New("localhost:11211"))
+
+// or a simple in-memory cache using weak pointers
+db.UseCache(mysql.NewWeakCache())
+
+// caches can be stacked
+db.UseCache(mysql.NewMultiCache(mysql.NewWeakCache(), mysql.NewRedisCache(r)))
 ```
 
 ## Usage

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,63 @@
+package mysql
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrCacheMiss is returned by Cache implementations when a key is not found.
+var ErrCacheMiss = errors.New("cache miss")
+
+// Cache defines basic get/set operations for query caching.
+type Cache interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+}
+
+// Locker provides optional distributed locking for cache population.
+type Locker interface {
+	Lock(ctx context.Context, key string) (func() error, error)
+}
+
+// MultiCache composes multiple caches. Reads check each cache in order and
+// populate earlier caches on a hit. Writes fan out to all caches.
+type MultiCache struct {
+	caches []Cache
+}
+
+// NewMultiCache creates a MultiCache from the provided caches.
+func NewMultiCache(caches ...Cache) *MultiCache { return &MultiCache{caches: caches} }
+
+func (m *MultiCache) Get(ctx context.Context, key string) ([]byte, error) {
+	var lastMiss error
+	for i, c := range m.caches {
+		b, err := c.Get(ctx, key)
+		if err == nil {
+			for j := 0; j < i; j++ {
+				_ = m.caches[j].Set(ctx, key, b, 0)
+			}
+			return b, nil
+		}
+		if !errors.Is(err, ErrCacheMiss) {
+			return nil, err
+		}
+		lastMiss = err
+	}
+	if lastMiss == nil {
+		lastMiss = ErrCacheMiss
+	}
+	return nil, lastMiss
+}
+
+func (m *MultiCache) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	var lastErr error
+	for _, c := range m.caches {
+		if err := c.Set(ctx, key, val, ttl); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+var _ Cache = (*MultiCache)(nil)

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,42 @@
+package mysql
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestWeakCache(t *testing.T) {
+	c := NewWeakCache()
+	if _, err := c.Get(context.Background(), "nope"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("expected miss")
+	}
+	if err := c.Set(context.Background(), "k", []byte("v"), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	b, err := c.Get(context.Background(), "k")
+	if err != nil || string(b) != "v" {
+		t.Fatalf("unexpected result %v %v", b, err)
+	}
+}
+
+func TestMultiCache(t *testing.T) {
+	wc := NewWeakCache()
+	mc := NewWeakCache()
+	m := NewMultiCache(wc, mc)
+	_ = m.Set(context.Background(), "a", []byte("b"), time.Minute)
+	b, err := wc.Get(context.Background(), "a")
+	if err != nil || string(b) != "b" {
+		t.Fatalf("weak cache not set")
+	}
+	// clear wc to force miss
+	wc.values = map[string]*weakEntry{}
+	b, err = m.Get(context.Background(), "a")
+	if err != nil || string(b) != "b" {
+		t.Fatalf("get failed %v %v", b, err)
+	}
+	if _, err = wc.Get(context.Background(), "a"); err != nil {
+		t.Fatalf("should populate first cache")
+	}
+}

--- a/database.go
+++ b/database.go
@@ -14,8 +14,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/go-redsync/redsync/v4"
-	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-sql-driver/mysql"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -32,14 +31,14 @@ type Database struct {
 
 	Log              LogFunc
 	Finished         FinishedFunc
-	HandleRedisError HandleRedisError
+	HandleCacheError HandleCacheError
 
 	die bool
 
 	MaxInsertSize *synct[int]
 
-	redis redis.UniversalClient
-	rs    *redsync.Redsync
+	cache  Cache
+	locker Locker
 
 	// DisableForeignKeyChecks only affects foreign keys for transactions
 	DisableForeignKeyChecks bool
@@ -73,9 +72,22 @@ func (db *Database) WriterWithSubdir(subdir string) *Database {
 // EnableRedis enables redis cache for select queries with cache times
 // with the given connection information
 func (db *Database) EnableRedis(redisClient redis.UniversalClient) *Database {
-	db.redis = redisClient
-	db.rs = redsync.New(goredis.NewPool(db.redis))
+	db.UseCache(NewRedisCache(redisClient))
+	return db
+}
 
+// EnableMemcache configures memcached as the cache backend.
+func (db *Database) EnableMemcache(mc *memcache.Client) *Database {
+	db.UseCache(NewMemcacheCache(mc))
+	return db
+}
+
+// UseCache sets a custom cache implementation.
+func (db *Database) UseCache(c Cache) *Database {
+	db.cache = c
+	if l, ok := c.(Locker); ok {
+		db.locker = l
+	}
 	return db
 }
 
@@ -97,9 +109,12 @@ type LogFunc func(detail LogDetail)
 // including being read from the channel if used
 type FinishedFunc func(cached bool, replacedQuery string, params Params, execDuration time.Duration, fetchDuration time.Duration)
 
-// HandleRedisError is executed on a redis error, so it can be handled by the user
-// return false to let the function return the error, or return to let the function continue executing despite the redis error
-type HandleRedisError func(err error) error
+// HandleCacheError is executed on a cache error so it can be handled by the user.
+// Returning a non-nil error will abort execution.
+type HandleCacheError func(err error) error
+
+// HandleRedisError is kept for backwards compatibility.
+type HandleRedisError = HandleCacheError
 
 func (db *Database) callLog(detail LogDetail) {
 	if db.Log != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,15 @@ toolchain go1.24.2
 
 require (
 	cloud.google.com/go v0.115.1
+	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/fatih/structtag v1.2.0
 	github.com/go-redsync/redsync/v4 v4.8.1
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/redis/go-redis/v9 v9.0.4
 	github.com/shopspring/decimal v1.3.1
+	github.com/stretchr/testify v1.10.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.35.0
@@ -19,7 +22,6 @@ require (
 )
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -28,7 +30,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf h1:TqhNAT4zKbTdLa62d2HDBFdvgSbIGB3eJE8HqhgiL9I=
+github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/bsm/ginkgo/v2 v2.5.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
 github.com/bsm/ginkgo/v2 v2.7.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
@@ -62,8 +64,10 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -92,8 +96,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
@@ -164,6 +166,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/memcache_cache.go
+++ b/memcache_cache.go
@@ -1,0 +1,34 @@
+package mysql
+
+import (
+	"context"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+)
+
+// MemcacheCache implements Cache using a memcached client.
+type MemcacheCache struct {
+	Client *memcache.Client
+}
+
+func NewMemcacheCache(client *memcache.Client) *MemcacheCache {
+	return &MemcacheCache{Client: client}
+}
+
+func (m *MemcacheCache) Get(ctx context.Context, key string) ([]byte, error) {
+	it, err := m.Client.Get(key)
+	if err == memcache.ErrCacheMiss {
+		return nil, ErrCacheMiss
+	}
+	if err != nil {
+		return nil, err
+	}
+	return it.Value, nil
+}
+
+func (m *MemcacheCache) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	return m.Client.Set(&memcache.Item{Key: key, Value: val, Expiration: int32(ttl.Seconds())})
+}
+
+var _ Cache = (*MemcacheCache)(nil)

--- a/redis_cache.go
+++ b/redis_cache.go
@@ -1,0 +1,51 @@
+package mysql
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-redsync/redsync/v4"
+	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisCache implements Cache and Locker using go-redis and redsync.
+type RedisCache struct {
+	Client redis.UniversalClient
+	rs     *redsync.Redsync
+}
+
+// NewRedisCache creates a RedisCache from a universal client.
+func NewRedisCache(client redis.UniversalClient) *RedisCache {
+	return &RedisCache{
+		Client: client,
+		rs:     redsync.New(goredis.NewPool(client)),
+	}
+}
+
+func (r *RedisCache) Get(ctx context.Context, key string) ([]byte, error) {
+	b, err := r.Client.Get(ctx, key).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrCacheMiss
+	}
+	return b, err
+}
+
+func (r *RedisCache) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	return r.Client.Set(ctx, key, val, ttl).Err()
+}
+
+func (r *RedisCache) Lock(ctx context.Context, key string) (func() error, error) {
+	m := r.rs.NewMutex(key, redsync.WithTries(1))
+	if err := m.LockContext(ctx); err != nil {
+		return nil, err
+	}
+	return func() error {
+		_, err := m.Unlock()
+		return err
+	}, nil
+}
+
+var _ Cache = (*RedisCache)(nil)
+var _ Locker = (*RedisCache)(nil)

--- a/weak_cache.go
+++ b/weak_cache.go
@@ -1,0 +1,60 @@
+//go:build go1.24
+
+package mysql
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"weak"
+)
+
+type weakEntry struct {
+	p       weak.Pointer[[]byte]
+	expires time.Time
+}
+
+// WeakCache stores values in memory using weak pointers so the garbage
+// collector may reclaim them under pressure.
+type WeakCache struct {
+	mu     sync.Mutex
+	values map[string]*weakEntry
+}
+
+func NewWeakCache() *WeakCache { return &WeakCache{values: make(map[string]*weakEntry)} }
+
+func (w *WeakCache) Get(ctx context.Context, key string) ([]byte, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	e, ok := w.values[key]
+	if !ok {
+		return nil, ErrCacheMiss
+	}
+	if !e.expires.IsZero() && time.Now().After(e.expires) {
+		delete(w.values, key)
+		return nil, ErrCacheMiss
+	}
+	if b := e.p.Value(); b != nil {
+		out := make([]byte, len(*b))
+		copy(out, *b)
+		return out, nil
+	}
+	delete(w.values, key)
+	return nil, ErrCacheMiss
+}
+
+func (w *WeakCache) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	buf := make([]byte, len(val))
+	copy(buf, val)
+	expires := time.Time{}
+	if ttl > 0 {
+		expires = time.Now().Add(ttl)
+	}
+	w.values[key] = &weakEntry{p: weak.Make(&buf), expires: expires}
+	return nil
+}
+
+var _ Cache = (*WeakCache)(nil)


### PR DESCRIPTION
## Summary
- add generic `Cache` interface with multi-cache support
- implement Redis, Memcached and weak-pointer caches
- enable caches via `UseCache`, `EnableRedis` and `EnableMemcache`
- update README with new caching options
- add unit tests for cache layers

## Testing
- `GOTOOLCHAIN=go1.24.2 go mod tidy`
- `GOTOOLCHAIN=go1.24.2 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f65c60660832fa26b15bb65cebde4