### PR TITLE
Add generic select helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ var name string
 err := db.Select(&name, "SELECT name FROM users WHERE id=@@id", 0, 5) // single param value
 ```
 
+### Typed selects with generics
+
+```go
+// fetch one row as a typed value
+user, err := mysql.SelectOne[User](db, "SELECT id, name FROM users WHERE id=1", 0)
+if err != nil {
+    log.Fatal(err)
+}
+
+// fetch many rows as a typed slice
+users, err := mysql.SelectSlice[User](db, "SELECT id, name FROM users", 0)
+```
+
 ### Selecting into channels
 
 ```go

--- a/generics_test.go
+++ b/generics_test.go
@@ -1,0 +1,45 @@
+package mysql
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSelectSliceGeneric(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	mock.ExpectQuery("^SELECT @@max_allowed_packet$").
+		WillReturnRows(sqlmock.NewRows([]string{"@@max_allowed_packet"}).AddRow(int64(4194304)))
+	rows := sqlmock.NewRows([]string{"foo"}).AddRow("a").AddRow("b")
+	mock.ExpectQuery("^SELECT foo FROM bar$").WillReturnRows(rows)
+
+	db, err := NewFromConn(mockDB, mockDB)
+	require.NoError(t, err)
+
+	res, err := SelectSlice[string](db, "SELECT foo FROM bar", 0)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, res)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSelectOneGeneric(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	mock.ExpectQuery("^SELECT @@max_allowed_packet$").
+		WillReturnRows(sqlmock.NewRows([]string{"@@max_allowed_packet"}).AddRow(int64(4194304)))
+	mock.ExpectQuery(`^SELECT count\(\*\) FROM bar WHERE id=1$`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+
+	db, err := NewFromConn(mockDB, mockDB)
+	require.NoError(t, err)
+
+	val, err := SelectOne[int](db, "SELECT count(*) FROM bar WHERE id=1", 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, val)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/typed_select.go
+++ b/typed_select.go
@@ -1,0 +1,70 @@
+package mysql
+
+import (
+	"context"
+	"time"
+)
+
+// SelectSliceContext executes a query and returns a typed slice using the Reads connection.
+func SelectSliceContext[T any](db *Database, ctx context.Context, q string, cache time.Duration, params ...any) ([]T, error) {
+	var dest []T
+	err := db.query(db.Reads, ctx, &dest, q, cache, params...)
+	if err != nil {
+		return nil, err
+	}
+	return dest, nil
+}
+
+// SelectSlice executes a query and returns a typed slice using the Reads connection.
+func SelectSlice[T any](db *Database, q string, cache time.Duration, params ...any) ([]T, error) {
+	return SelectSliceContext[T](db, context.Background(), q, cache, params...)
+}
+
+// SelectOneContext executes a query and returns a single typed value using the Reads connection.
+func SelectOneContext[T any](db *Database, ctx context.Context, q string, cache time.Duration, params ...any) (T, error) {
+	var dest T
+	err := db.query(db.Reads, ctx, &dest, q, cache, params...)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return dest, nil
+}
+
+// SelectOne executes a query and returns a single typed value using the Reads connection.
+func SelectOne[T any](db *Database, q string, cache time.Duration, params ...any) (T, error) {
+	return SelectOneContext[T](db, context.Background(), q, cache, params...)
+}
+
+// Tx helpers
+
+// TxSelectSliceContext executes a query on the transaction and returns a typed slice.
+func TxSelectSliceContext[T any](tx *Tx, ctx context.Context, q string, cache time.Duration, params ...any) ([]T, error) {
+	var dest []T
+	err := tx.db.query(tx.Tx, ctx, &dest, q, cache, params...)
+	if err != nil {
+		return nil, err
+	}
+	return dest, nil
+}
+
+// TxSelectSlice executes a query on the transaction and returns a typed slice.
+func TxSelectSlice[T any](tx *Tx, q string, cache time.Duration, params ...any) ([]T, error) {
+	return TxSelectSliceContext[T](tx, context.Background(), q, cache, params...)
+}
+
+// TxSelectOneContext executes a query on the transaction and returns a single typed value.
+func TxSelectOneContext[T any](tx *Tx, ctx context.Context, q string, cache time.Duration, params ...any) (T, error) {
+	var dest T
+	err := tx.db.query(tx.Tx, ctx, &dest, q, cache, params...)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return dest, nil
+}
+
+// TxSelectOne executes a query on the transaction and returns a single typed value.
+func TxSelectOne[T any](tx *Tx, q string, cache time.Duration, params ...any) (T, error) {
+	return TxSelectOneContext[T](tx, context.Background(), q, cache, params...)
+}


### PR DESCRIPTION
## Summary
- add generic select helpers for retrieving typed values or slices
- document new typed select functions in README
- test generic helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f67e6e7cc832f8c4cff0b22f667fd