### PR TITLE
Introduce functional options and cache defaults

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -8,8 +8,6 @@ import (
 // Since we are using 30 second limited AWS Lambda functions, we'll default this time to
 // 90% of 30 seconds (27 seconds), with the goal of letting our process clean up and correctly
 // log any failed queries
-var MaxExecutionTime = time.Duration(getenvInt64("COOL_MAX_EXECUTION_TIME_TIME", int64(float64(30)*.9))) * time.Second
-
-var MaxConnectionTime = MaxExecutionTime
-
-var RedisLockRetryDelay = time.Duration(getenvFloat("COOL_REDIS_LOCK_RETRY_DELAY", .020)) * time.Second
+var defaultMaxExecutionTime = time.Duration(getenvInt64("COOL_MAX_EXECUTION_TIME_TIME", int64(float64(30)*.9))) * time.Second
+var defaultConnectionTime = defaultMaxExecutionTime
+var defaultRedisLockRetryDelay = time.Duration(getenvFloat("COOL_REDIS_LOCK_RETRY_DELAY", .020)) * time.Second

--- a/exec.go
+++ b/exec.go
@@ -32,7 +32,7 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 	var res sql.Result
 
 	var b = backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = MaxExecutionTime
+	b.MaxElapsedTime = db.maxExecutionTime
 	var attempt int
 	var rowsAffected int64
 	exec := func() error {

--- a/exists.go
+++ b/exists.go
@@ -68,7 +68,7 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 
 			if err = mutex.Lock(); err != nil {
 				// if we couldn't get the lock, then just check the cache again
-				time.Sleep(RedisLockRetryDelay)
+				time.Sleep(db.redisLockRetryDelay)
 				goto CHECK_CACHE
 			}
 
@@ -113,7 +113,7 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 	start := time.Now()
 
 	var b = backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = MaxExecutionTime
+	b.MaxElapsedTime = db.maxExecutionTime
 	var attempt int
 	err = backoff.Retry(func() error {
 		attempt++

--- a/options.go
+++ b/options.go
@@ -1,0 +1,26 @@
+package mysql
+
+import "time"
+
+// Option configures a Database.
+type Option func(*Database)
+
+// WithMaxExecutionTime sets the maximum backoff elapsed time for queries.
+func WithMaxExecutionTime(d time.Duration) Option {
+	return func(db *Database) { db.maxExecutionTime = d }
+}
+
+// WithConnectionLifetime sets the maximum lifetime for connections.
+func WithConnectionLifetime(d time.Duration) Option {
+	return func(db *Database) { db.maxConnectionTime = d }
+}
+
+// WithRedisLockRetryDelay sets the delay between lock retries when caching.
+func WithRedisLockRetryDelay(d time.Duration) Option {
+	return func(db *Database) { db.redisLockRetryDelay = d }
+}
+
+// WithDefaultCacheDuration sets a default cache duration for Select/Exists helpers.
+func WithDefaultCacheDuration(d time.Duration) Option {
+	return func(db *Database) { db.defaultCacheDuration = d }
+}

--- a/select.go
+++ b/select.go
@@ -126,7 +126,7 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 
 			if err = mutex.Lock(); err != nil {
 				// if we couldn't get the lock, then just check the cache again
-				time.Sleep(RedisLockRetryDelay)
+				time.Sleep(db.redisLockRetryDelay)
 				goto CHECK_CACHE
 			}
 
@@ -197,7 +197,7 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 	start := time.Now()
 
 	var b = backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = MaxExecutionTime
+	b.MaxElapsedTime = db.maxExecutionTime
 	var attempt int
 	err = backoff.Retry(func() error {
 		attempt++


### PR DESCRIPTION
## Summary
- replace global timeout variables with per-`Database` fields
- add functional options (`WithMaxExecutionTime`, `WithConnectionLifetime`, `WithRedisLockRetryDelay`, `WithDefaultCacheDuration`)
- allow new constructors to accept options
- provide wrapper methods that use a default cache duration
- rename `main.go` to `defaults.go`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f6de3ed98832fab4d5969c52a33c2