### PR TITLE
Refactor logger use for structured output

### DIFF
--- a/exists.go
+++ b/exists.go
@@ -74,7 +74,7 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 			defer func() {
 				if unlockFn != nil {
 					if err := unlockFn(); err != nil {
-						db.Logger.Warn(fmt.Sprintf("failed to unlock cache mutex: %v", err))
+						db.Logger.Warn("failed to unlock cache mutex", "err", err)
 					}
 				}
 			}()

--- a/select.go
+++ b/select.go
@@ -132,7 +132,7 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 			defer func() {
 				if unlockFn != nil {
 					if err := unlockFn(); err != nil {
-						db.Logger.Warn(fmt.Sprintf("failed to unlock cache mutex: %v", err))
+						db.Logger.Warn("failed to unlock cache mutex", "err", err)
 					}
 				}
 			}()
@@ -470,7 +470,7 @@ func setupElementPtrs(db *Database, t reflect.Type, indirectType reflect.Type, c
 			fieldIndex, ok := fieldsMap[c]
 			if !ok {
 				if !db.DisableUnusedColumnWarnings {
-					db.Logger.Warn(fmt.Sprintf("column %q from query doesn't belong to any struct fields", c))
+					db.Logger.Warn("unused column", "column", c)
 				}
 				continue
 			}

--- a/zaplogger.go
+++ b/zaplogger.go
@@ -5,7 +5,7 @@ import "go.uber.org/zap"
 // ZapLogger adapts zap.Logger to the Logger interface.
 type ZapLogger struct{ *zap.Logger }
 
-func (l ZapLogger) Debug(msg string, args ...any) { l.Logger.Sugar().Debugf(msg, args...) }
-func (l ZapLogger) Info(msg string, args ...any)  { l.Logger.Sugar().Infof(msg, args...) }
-func (l ZapLogger) Warn(msg string, args ...any)  { l.Logger.Sugar().Warnf(msg, args...) }
-func (l ZapLogger) Error(msg string, args ...any) { l.Logger.Sugar().Errorf(msg, args...) }
+func (l ZapLogger) Debug(msg string, args ...any) { l.Logger.Sugar().Debugw(msg, args...) }
+func (l ZapLogger) Info(msg string, args ...any)  { l.Logger.Sugar().Infow(msg, args...) }
+func (l ZapLogger) Warn(msg string, args ...any)  { l.Logger.Sugar().Warnw(msg, args...) }
+func (l ZapLogger) Error(msg string, args ...any) { l.Logger.Sugar().Errorw(msg, args...) }


### PR DESCRIPTION
## Summary
- adapt zap logger to use structured fields
- use structured log fields for cache mutex unlock failures
- improve unused column warning logging

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68404788d864832f826ce594b6ea0411