### PR TITLE
fix: timezone offset calculation and test improvements

### DIFF
--- a/database.go
+++ b/database.go
@@ -69,13 +69,7 @@ func setSessionTimezone(exec interface {
 
 	if config.Loc != nil {
 		_, offset := time.Now().In(config.Loc).Zone()
-		offsetHours := offset / 3600
-		offsetMinutes := (offset % 3600) / 60
-		if offsetMinutes < 0 {
-			offsetMinutes = -offsetMinutes
-		}
-
-		timeZoneStr := fmt.Sprintf("%+03d:%02d", offsetHours, offsetMinutes)
+		timeZoneStr := time.Unix(0, 0).In(time.FixedZone("", offset)).Format("-07:00")
 
 		_, err = exec.Exec("SET time_zone = ?", timeZoneStr)
 		if err != nil {

--- a/database.go
+++ b/database.go
@@ -71,13 +71,11 @@ func setSessionTimezone(exec interface {
 		_, offset := time.Now().In(config.Loc).Zone()
 		offsetHours := offset / 3600
 		offsetMinutes := (offset % 3600) / 60
-
-		var timeZoneStr string
-		if offset == 0 {
-			timeZoneStr = "+00:00"
-		} else {
-			timeZoneStr = fmt.Sprintf("%+03d:%02d", offsetHours, offsetMinutes)
+		if offsetMinutes < 0 {
+			offsetMinutes = -offsetMinutes
 		}
+
+		timeZoneStr := fmt.Sprintf("%+03d:%02d", offsetHours, offsetMinutes)
 
 		_, err = exec.Exec("SET time_zone = ?", timeZoneStr)
 		if err != nil {

--- a/select_test.go
+++ b/select_test.go
@@ -592,8 +592,9 @@ func TestSelectChannelUnexportedField(t *testing.T) {
 
 	type row struct {
 		Foo string
+		bar int //nolint:unused
 	}
 	ch := make(chan row)
-	err := db.Select(ch, "SELECT foo FROM bar", 0)
-	require.Error(t, err)
+	err := db.Select(ch, "SELECT foo, bar FROM table_name", 0)
+	require.ErrorIs(t, err, ErrUnexportedField)
 }


### PR DESCRIPTION
## Summary
- Fix timezone offset calculation bug where negative offsets showed negative minutes (e.g., UTC-03:30 displayed as `-03:-30` instead of `-03:30`)
- Improve TestSelectChannelUnexportedField to properly test unexported field error handling with specific error assertion
- Simplify timezone string formatting logic by removing redundant zero-offset special case

## Test plan
- [x] Verify timezone offset formatting works correctly for negative offsets
- [x] Confirm TestSelectChannelUnexportedField properly tests unexported field detection
- [x] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)