### PR TITLE
Add configurable max attempts and upgrade backoff

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -1,0 +1,52 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+type stubResult struct{}
+
+func (stubResult) LastInsertId() (int64, error) { return 0, nil }
+func (stubResult) RowsAffected() (int64, error) { return 0, nil }
+
+type failingExecHandler struct {
+	errors []error
+	calls  int
+}
+
+func (h *failingExecHandler) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	h.calls++
+	if h.calls <= len(h.errors) {
+		return nil, h.errors[h.calls-1]
+	}
+	return stubResult{}, nil
+}
+
+func (h *failingExecHandler) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	panic("unexpected QueryContext call in failingExecHandler")
+}
+
+func TestExecRespectsMaxAttempts(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 3
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	h := &failingExecHandler{
+		errors: []error{errMockRetry, errMockRetry, errMockRetry, errMockRetry},
+	}
+
+	db := &Database{}
+	_, err := db.exec(h, context.Background(), nil, true, "SELECT 1")
+	if err == nil {
+		t.Fatalf("expected error after retries exhausted")
+	}
+	if !errors.Is(err, errMockRetry) {
+		t.Fatalf("expected errMockRetry, got %v", err)
+	}
+	if h.calls != MaxAttempts {
+		t.Fatalf("expected %d attempts, got %d", MaxAttempts, h.calls)
+	}
+}

--- a/exists.go
+++ b/exists.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/go-sql-driver/mysql"
 	"golang.org/x/crypto/sha3"
 )
@@ -102,24 +102,13 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 		}
 	}
 
-	var rows *sql.Rows
-	defer func() {
-		if rows != nil {
-			if err := rows.Close(); err != nil {
-				db.Logger.Warn("failed to close rows", "err", err)
-			}
-		}
-	}()
-
 	start := time.Now()
 
 	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = MaxExecutionTime
 	var attempt int
-	err = backoff.Retry(func() error {
+	operation := func() (*sql.Rows, error) {
 		attempt++
-		var err error
-		rows, err = conn.QueryContext(ctx, replacedQuery)
+		rows, err := conn.QueryContext(ctx, replacedQuery)
 		tx, _ := conn.(*sql.Tx)
 		db.callLog(LogDetail{
 			Query:    replacedQuery,
@@ -131,19 +120,34 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 		})
 		if err != nil {
 			if checkRetryError(err) {
-				return err
-			} else if errors.Is(err, mysql.ErrInvalidConn) {
-				return db.Test()
-			} else {
-				return backoff.Permanent(err)
+				return nil, err
 			}
+			if errors.Is(err, mysql.ErrInvalidConn) {
+				return nil, db.Test()
+			}
+			return nil, backoff.Permanent(err)
 		}
 
-		return nil
-	}, backoff.WithContext(b, ctx))
+		return rows, nil
+	}
+
+	options := []backoff.RetryOption{
+		backoff.WithBackOff(b),
+		backoff.WithMaxElapsedTime(MaxExecutionTime),
+	}
+	if MaxAttempts > 0 {
+		options = append(options, backoff.WithMaxTries(uint(MaxAttempts)))
+	}
+
+	rows, err := backoff.Retry(ctx, operation, options...)
 	if err != nil {
 		return exists, err
 	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			db.Logger.Warn("failed to close rows", "err", err)
+		}
+	}()
 
 	exists = rows.Next()
 	if err = rows.Err(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go v0.115.1
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf
-	github.com/cenkalti/backoff/v4 v4.2.1
+	github.com/cenkalti/backoff/v5 v5.0.1
 	github.com/fatih/structtag v1.2.0
 	github.com/go-redsync/redsync/v4 v4.8.1
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/bsm/ginkgo/v2 v2.7.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ
 github.com/bsm/gomega v1.20.0/go.mod h1:JifAceMQ4crZIWYUKrlGcmbN3bqHogVTADMD2ATsbwk=
 github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
 github.com/bsm/gomega v1.26.0/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
-github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
-github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.1 h1:kGZdCHH1+eW+Yd0wftimjMuhg9zidDvNF5aGdnkkb+U=
+github.com/cenkalti/backoff/v5 v5.0.1/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/main.go
+++ b/main.go
@@ -12,4 +12,7 @@ var MaxExecutionTime = time.Duration(getenvInt64("COOL_MAX_EXECUTION_TIME_TIME",
 
 var MaxConnectionTime = MaxExecutionTime
 
+// MaxAttempts caps total attempts per query, including the first try (<=0 disables the cap).
+var MaxAttempts = getenvInt("COOL_MAX_ATTEMPTS", 0)
+
 var RedisLockRetryDelay = time.Duration(getenvFloat("COOL_REDIS_LOCK_RETRY_DELAY", .020)) * time.Second


### PR DESCRIPTION
## Summary
- add MaxAttempts configuration via COOL_MAX_ATTEMPTS to cap total query attempts
- migrate retry loops to github.com/cenkalti/backoff/v5 and add coverage for the limit

## Testing
- go test ./...