### PR TITLE
Add plugin marketplace configuration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "cool-mysql",
+  "owner": {
+    "name": "Stirling Marketing Group"
+  },
+  "plugins": [
+    {
+      "name": "cool-mysql",
+      "source": "./.claude/skills/cool-mysql",
+      "description": "Comprehensive guide for cool-mysql Go library - MySQL helper with dual connection pools, named parameters, template syntax, caching, and advanced query patterns"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` to enable installation of the cool-mysql skill via the Claude Code plugin marketplace.

## Changes

- Created `.claude-plugin/marketplace.json` with plugin configuration
- Users can now install with: `/plugin marketplace add StirlingMarketingGroup/cool-mysql`

## Testing

- [x] File structure follows Claude Code plugin marketplace format
- [x] JSON is valid
- [x] Description accurately describes the skill

## Installation Instructions

After merge, users can install the skill with:

```bash
/plugin marketplace add StirlingMarketingGroup/cool-mysql
/plugin install cool-mysql@cool-mysql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)