### PR TITLE
fix: use indirectEl.Type() instead of el.Type() for FieldByIndex error message

### DIFF
--- a/select.go
+++ b/select.go
@@ -321,7 +321,7 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 				f := indirectEl.FieldByIndex(jsonField.index)
 				err = json.Unmarshal(jsonField.j, f.Addr().Interface())
 				if err != nil {
-					return fmt.Errorf("failed to unmarshal json into struct field %q: %w", el.Type().FieldByIndex(jsonField.index).Name, err)
+					return fmt.Errorf("failed to unmarshal json into struct field %q: %w", indirectEl.Type().FieldByIndex(jsonField.index).Name, err)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixes panic when JSON unmarshaling fails during scan into slice of pointer types (e.g., `[]*SomeStruct`)
- The `el` variable is a pointer type, but `FieldByIndex` requires a struct type
- Changed error message on line 324 to use `indirectEl.Type()` (already unwrapped) instead of `el.Type()`

Closes #130

## The Bug

When scanning into a slice of pointer types and JSON unmarshaling fails, the error message construction panicked:

```
panic: reflect: FieldByIndex of non-struct type *SomeStruct
```

This happened because `el.Type()` was used on a pointer type, but `reflect.Type.FieldByIndex()` only works on struct types.

## The Fix

```diff
- return fmt.Errorf("failed to unmarshal json into struct field %q: %w", el.Type().FieldByIndex(jsonField.index).Name, err)
+ return fmt.Errorf("failed to unmarshal json into struct field %q: %w", indirectEl.Type().FieldByIndex(jsonField.index).Name, err)
```

The code was already correctly using `indirectEl` (the unwrapped struct value) for the actual field access. This fix makes the error message consistent.

## Test Plan

- [ ] Attempt to scan invalid JSON into a slice of pointer types - should now return a proper error instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)