### PR TITLE
Fix panic in JSON unmarshal error handling for pointer element types

### DIFF
--- a/select.go
+++ b/select.go
@@ -321,7 +321,7 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 				f := indirectEl.FieldByIndex(jsonField.index)
 				err = json.Unmarshal(jsonField.j, f.Addr().Interface())
 				if err != nil {
-					return fmt.Errorf("failed to unmarshal json into struct field %q: %w", el.Type().FieldByIndex(jsonField.index).Name, err)
+					return fmt.Errorf("failed to unmarshal json into struct field %q: %w", indirectEl.Type().FieldByIndex(jsonField.index).Name, err)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Fixes #130: Panic when JSON unmarshal fails for pointer element type
- Uses `indirectEl.Type()` instead of `el.Type()` when constructing error message
- Adds regression test to prevent future occurrences

## Test plan
- [x] Added test `TestSelectJSONUnmarshalErrorWithPointerElement` that reproduces the panic
- [x] Verified test fails before fix (RED)
- [x] Verified test passes after fix (GREEN)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)