### PR TITLE
Add noinsert tag option for select-only fields

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -400,7 +400,7 @@ func colNamesFromStruct(t reflect.Type) (columns []string, colOpts map[string]in
 
 		t, _ := structtag.Parse(string(f.Tag))
 		if t, _ := t.Get("mysql"); t != nil {
-			if t.Name == "-" {
+			if t.Name == "-" || t.HasOption("noinsert") {
 				continue
 			}
 


### PR DESCRIPTION
## Summary
- Adds new `noinsert` option for the mysql struct tag
- Fields with `noinsert` are skipped for INSERTs but still participate in SELECT column mapping
- Closes #133

## The Problem
When using `mysql:"-"`, the field is skipped for inserts but still maps by **struct field name** for selects. This causes conflicts when another field explicitly maps to the same column name:

```go
type OrderLineItem struct {
    CustomLineItem *string   `mysql:"LineItem"`  // maps to "lineitem"
    LineItem       *LineItem `mysql:"-"`          // also maps to "lineitem" by struct name - OVERWRITES!
}
```

## The Solution
Use `noinsert` to specify an explicit column name for selects while skipping inserts:

```go
type OrderLineItem struct {
    CustomLineItem *string   `mysql:"LineItem"`               // maps to "LineItem" 
    LineItem       *LineItem `mysql:"LineItemModel,noinsert"` // maps to "LineItemModel" for select, skipped for insert
}
```

## Test plan
- [x] Added test `TestNoInsertTagOption` verifying `colNamesFromStruct` skips noinsert fields
- [x] Added test verifying INSERT output excludes noinsert fields
- [x] Added test `TestSelectNoInsertFieldMapping` verifying SELECT still maps noinsert fields correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)