### PR TITLE
Deprecate mysql:"-" tag in favor of noinsert option

### DIFF
--- a/.claude/skills/cool-mysql/SKILL.md
+++ b/.claude/skills/cool-mysql/SKILL.md
@@ -149,7 +149,8 @@ Control column mapping and behavior with `mysql` struct tags.
 - `mysql:"column_name,defaultzero"` - Write `DEFAULT(column_name)` for zero values
 - `mysql:"column_name,omitempty"` - Same as `defaultzero`
 - `mysql:"column_name,insertDefault"` - Same as `defaultzero`
-- `mysql:"-"` - Completely ignore this field
+- `mysql:"column_name,noinsert"` - Skip this field for inserts; still works in selects and params
+- `mysql:"-"` - **Deprecated**, use `noinsert` instead. Only skips inserts despite appearances
 - `mysql:"column0x2cname"` - Hex encoding for special characters (becomes `column,name`)
 
 **Example:**
@@ -160,7 +161,7 @@ type User struct {
     Email     string    `mysql:"email"`
     CreatedAt time.Time `mysql:"created_at,defaultzero"` // Use DB default on zero value
     UpdatedAt time.Time `mysql:"updated_at,defaultzero"`
-    Password  string    `mysql:"-"` // Never include in queries
+    Password  string    `mysql:"password,noinsert"` // Skipped for inserts, still works in selects
 }
 ```
 
@@ -331,7 +332,7 @@ return db.Select(&users, "SELECT `id`, `name`, `email`, `age`, `active`, `create
 
 **DO:**
 - Use `defaultzero` for timestamp columns with DB defaults
-- Use `mysql:"-"` to exclude sensitive fields
+- Use `noinsert` option to exclude fields from inserts
 - Use hex encoding for column names with special characters
 - Implement `Zeroer` interface for custom zero-value detection
 

--- a/.claude/skills/cool-mysql/references/struct-tags.md
+++ b/.claude/skills/cool-mysql/references/struct-tags.md
@@ -52,7 +52,8 @@ type User struct {
 | Default zero | `mysql:"column_name,defaultzero"` | Use DEFAULT() for zero values |
 | Omit empty | `mysql:"column_name,omitempty"` | Same as `defaultzero` |
 | Insert default | `mysql:"column_name,insertDefault"` | Same as `defaultzero` |
-| Ignore field | `mysql:"-"` | Completely ignore field |
+| No insert | `mysql:"column_name,noinsert"` | Skip for inserts; still used in selects and params |
+| Ignore field | `mysql:"-"` | **Deprecated** — use `noinsert` instead. Only skips inserts despite appearances |
 
 ### Column Name Only
 
@@ -101,17 +102,29 @@ type User struct {
 // Equivalent to defaultzero
 ```
 
-### Ignore Field
+### No Insert (noinsert)
 
 ```go
 type User struct {
     ID       int    `mysql:"id"`
-    Password string `mysql:"-"` // Never included in queries
-    internal string // Unexported fields also ignored
+    Password string `mysql:"password_hash,noinsert"` // Skipped for inserts, still works in selects
+    internal string                                   // Unexported fields also ignored
 }
 
 // INSERT INTO `users` (id) VALUES (?)
-// Password is never inserted or selected
+// password_hash is skipped for inserts but still maps during SELECT
+```
+
+### Ignore Field (Deprecated)
+
+> **Deprecated:** `mysql:"-"` is misleading because it only skips inserts, not selects
+> or parameter interpolation. Use `noinsert` instead for clarity.
+
+```go
+// Deprecated — use noinsert instead
+type User struct {
+    Password string `mysql:"-"` // Only skips inserts, NOT selects or params
+}
 ```
 
 ## Default Value Handling
@@ -368,14 +381,14 @@ db.Insert("users", User{
 })
 ```
 
-### Ignored Fields with Computed Values
+### Fields Excluded from Inserts
 
 ```go
 type User struct {
     ID        int       `mysql:"id"`
     FirstName string    `mysql:"first_name"`
     LastName  string    `mysql:"last_name"`
-    FullName  string    `mysql:"-"` // Computed, not in DB
+    FullName  string    `mysql:"full_name,noinsert"` // Skipped for inserts, but available in selects
 }
 
 var users []User
@@ -495,13 +508,14 @@ type User struct {
 
 ```go
 type User struct {
-    DatabaseID   int    `mysql:"id"`      // Database column
-    UserName     string `mysql:"username"` // Database column
-    ComputedRank int    `mysql:"-"`       // Not in database
+    DatabaseID   int    `mysql:"id"`                    // Database column
+    UserName     string `mysql:"username"`               // Database column
+    ComputedRank int    `mysql:"computed_rank,noinsert"` // Populated from SELECT, skipped for inserts
 }
 
-// Database columns: id, username
-// Struct fields: DatabaseID, UserName, ComputedRank
+// Database columns: id, username, computed_rank
+// Insert only writes: id, username (computed_rank is noinsert)
+// Select can read all three columns
 ```
 
 ## Best Practices
@@ -540,13 +554,13 @@ type User struct {
 }
 ```
 
-### 4. Ignore Computed Fields
+### 4. Skip Computed Fields from Inserts
 
 ```go
 type User struct {
     FirstName string `mysql:"first_name"`
     LastName  string `mysql:"last_name"`
-    FullName  string `mysql:"-"` // Computed field
+    FullName  string `mysql:"full_name,noinsert"` // Skipped for inserts
 }
 ```
 
@@ -617,9 +631,8 @@ type User struct {
     // JSON column
     Metadata json.RawMessage `mysql:"metadata"`
 
-    // Ignored fields
-    Password     string `mysql:"-"` // Never persisted
-    PasswordHash string `mysql:"password_hash"`
+    // Insert-excluded fields
+    PasswordHash string `mysql:"password_hash,noinsert"` // Skipped for inserts, available in selects
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ Fields in a struct can include a `mysql` tag to control how they map to the data
 - `defaultzero` – write `default(column_name)` instead of the zero value during inserts and parameter interpolation
 - `insertDefault` – alias for `defaultzero` (same behavior)
 - `omitempty` – alias for `defaultzero` (same behavior)
-- `"-"` – skip this field entirely (not included in inserts, selects, or parameter interpolation)
+- `noinsert` – skip this field for inserts only; the field still participates in selects and parameter interpolation
+- `"-"` – **deprecated**, use `noinsert` instead. Despite appearances, `"-"` only skips inserts — the field is still used for selects (mapped by its Go field name) and parameter interpolation
 
 **Hex encoding support:**
 Column names can include hex-encoded characters using `0x` notation (e.g., `0x2c` for comma, `0x20` for space).
@@ -301,15 +302,15 @@ Column names can include hex-encoded characters using `0x` notation (e.g., `0x2c
 type Person struct {
     ID       int       `mysql:"id"`
     Name     string    `mysql:"name,defaultzero"`
-    Email    string    `mysql:"email,omitempty"`        // same as defaultzero
-    Internal string    `mysql:"-"`                      // completely ignored
+    Email    string    `mysql:"email,omitempty"`          // same as defaultzero
+    Internal string    `mysql:"internal,noinsert"`        // skipped for inserts, still works in selects
     Created  time.Time `mysql:"created_at,insertDefault"` // same as defaultzero
-    Special  string    `mysql:"column0x2cname"`         // becomes "column,name"
+    Special  string    `mysql:"column0x2cname"`           // becomes "column,name"
 }
 
 db.Insert("people", Person{})
 // name, email, created_at become default(`name`), default(`email`), default(`created_at`)
-// Internal field is completely ignored
+// Internal field is skipped for inserts, but still works in selects
 
 _, _, _ = mysql.InterpolateParams(
     "SELECT * FROM people WHERE name = @@Name",

--- a/insert.go
+++ b/insert.go
@@ -400,6 +400,10 @@ func colNamesFromStruct(t reflect.Type) (columns []string, colOpts map[string]in
 
 		t, _ := structtag.Parse(string(f.Tag))
 		if t, _ := t.Get("mysql"); t != nil {
+			// Deprecated: mysql:"-" is supported for backwards compatibility but
+			// is misleading because it only skips inserts, not selects or parameter
+			// interpolation. Use the "noinsert" option instead:
+			//   mysql:"column_name,noinsert"
 			if t.Name == "-" || t.HasOption("noinsert") {
 				continue
 			}

--- a/select.go
+++ b/select.go
@@ -467,6 +467,9 @@ func setupElementPtrs(db *Database, t reflect.Type, indirectType reflect.Type, c
 
 			name := f.Name
 			mysqlTag, _ := tags.Get("mysql")
+			// Note: mysql:"-" fields are NOT skipped for selects — the "-" is
+			// only treated specially during inserts. The field maps to its Go
+			// name for select column matching. Prefer "noinsert" over "-".
 			if mysqlTag != nil && len(mysqlTag.Name) != 0 && mysqlTag.Name != "-" {
 				name, err = decodeHex(mysqlTag.Name)
 				if err != nil {


### PR DESCRIPTION
## Summary
- Deprecates `mysql:"-"` struct tag with code comments and updated docs — it only skips inserts, not selects or parameter interpolation, which is confusing (even our own docs got it wrong)
- Recommends `mysql:"column_name,noinsert"` as the replacement, which clearly communicates the actual behavior
- `mysql:"-"` continues to work for backwards compatibility

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint` clean
- [x] GPT-5.4 code review confirmed changes match runtime behavior
- [x] No behavioral changes — comments and docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)