### PR TITLE
Add PostRollbackHooks to Tx (#139)

### DIFF
--- a/.claude/skills/cool-mysql/SKILL.md
+++ b/.claude/skills/cool-mysql/SKILL.md
@@ -421,6 +421,23 @@ if err := commit(); err != nil {
 }
 ```
 
+**Transaction Hooks:**
+
+`PostCommitHooks` run after a successful commit and can return errors. `PostRollbackHooks` run after a real rollback (not when `cancel()` is called on an already-committed transaction) and do not return errors since the transaction has already failed.
+
+```go
+// Run cleanup after commit
+tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+    defer collectors.Delete(tx)
+    return flush()
+})
+
+// Run cleanup after rollback (e.g., clean up sync.Map entries)
+tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+    collectors.Delete(tx)
+})
+```
+
 ### Custom Interfaces
 
 **Custom zero detection:**

--- a/.claude/skills/cool-mysql/examples/transaction-patterns.go
+++ b/.claude/skills/cool-mysql/examples/transaction-patterns.go
@@ -37,20 +37,24 @@ func TransactionExamples() {
 	fmt.Println("\n4. Complex Multi-Step Transaction")
 	complexTransactionExample()
 
+	// Transaction hooks
+	fmt.Println("\n5. Transaction Hooks (PostCommit/PostRollback)")
+	transactionHooksExample(context.Background(), db)
+
 	// Batch transaction
-	fmt.Println("\n5. Batch Transaction")
+	fmt.Println("\n6. Batch Transaction")
 	batchTransactionExample(context.Background(), db)
 
 	// Transaction with retry
-	fmt.Println("\n6. Transaction with Retry Logic")
+	fmt.Println("\n7. Transaction with Retry Logic")
 	transactionWithRetry(context.Background(), db)
 
 	// Savepoint example
-	fmt.Println("\n7. Savepoint Pattern")
+	fmt.Println("\n8. Savepoint Pattern")
 	savepointExample(context.Background(), db)
 
 	// Isolation level
-	fmt.Println("\n8. Custom Isolation Level")
+	fmt.Println("\n9. Custom Isolation Level")
 	isolationLevelExample(context.Background(), db)
 }
 
@@ -411,6 +415,52 @@ func transferFunds(ctx context.Context, db *mysql.Database, fromEmail, toEmail s
 	}
 
 	fmt.Println("  All changes committed atomically")
+	return nil
+}
+
+// transactionHooksExample demonstrates PostCommitHooks and PostRollbackHooks
+func transactionHooksExample(ctx context.Context, db *mysql.Database) error {
+	fmt.Println("\nTransaction Hooks Example")
+
+	tx, commit, cancel, err := mysql.GetOrCreateTxFromContext(ctx)
+	defer cancel()
+	if err != nil {
+		return err
+	}
+
+	ctx = mysql.NewContextWithTx(ctx, tx)
+
+	// PostCommitHooks run after a successful commit and can return errors
+	tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+		fmt.Println("  PostCommitHook: flushing batched events")
+		// e.g., flush batched node event instances
+		return nil
+	})
+
+	// PostRollbackHooks run after a real rollback (not when cancel() is
+	// called on an already-committed transaction). They don't return errors
+	// since the transaction has already failed.
+	tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+		fmt.Println("  PostRollbackHook: cleaning up external state")
+		// e.g., remove sync.Map entries keyed by this transaction
+	})
+
+	// Perform transaction operations using tx (not db) so they run inside the transaction
+	err = tx.Insert("users", User{
+		Name:   "HooksUser",
+		Email:  "hooks@example.com",
+		Age:    30,
+		Active: true,
+	})
+	if err != nil {
+		return err // cancel() triggers PostRollbackHooks
+	}
+
+	if err := commit(); err != nil {
+		return err
+	}
+
+	fmt.Println("✓ Transaction committed, PostCommitHooks executed")
 	return nil
 }
 

--- a/.claude/skills/cool-mysql/references/api-reference.md
+++ b/.claude/skills/cool-mysql/references/api-reference.md
@@ -457,15 +457,15 @@ Context-aware version of `ExecResult()`.
 
 ### GetOrCreateTxFromContext
 ```go
-func GetOrCreateTxFromContext(ctx context.Context) (*sql.Tx, func() error, func(), error)
+func GetOrCreateTxFromContext(ctx context.Context) (tx *Tx, commit, cancel func() error, err error)
 ```
 
 Get existing transaction from context or create new one.
 
 **Returns:**
-- `*sql.Tx` - Transaction instance
+- `*Tx` - Transaction instance
 - `func() error` - Commit function
-- `func()` - Cancel function (rolls back if not committed)
+- `func() error` - Cancel function (rolls back if not committed)
 - `error` - Transaction creation error
 
 **Usage Pattern:**
@@ -486,23 +486,49 @@ if err := commit(); err != nil {
 }
 ```
 
+### Tx.PostCommitHooks
+```go
+PostCommitHooks []func() error
+```
+
+Functions to run after a successful commit. Hooks run sequentially; if any hook returns an error, it is wrapped and returned from `Commit()`.
+
+```go
+tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+    defer collectors.Delete(tx)
+    return flush()
+})
+```
+
+### Tx.PostRollbackHooks
+```go
+PostRollbackHooks []func()
+```
+
+Functions to run after a real rollback. Hooks do **not** run when `Cancel()` is called on an already-committed transaction (the common `defer cancel()` pattern). They do not return errors since the transaction has already failed.
+
+```go
+tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+    collectors.Delete(tx)
+})
+```
+
 ### NewContextWithTx
 ```go
-func NewContextWithTx(ctx context.Context, tx *sql.Tx) context.Context
+func NewContextWithTx(ctx context.Context, tx *Tx) context.Context
 ```
 
 Store transaction in context for use by database operations.
 
 ### TxFromContext
 ```go
-func TxFromContext(ctx context.Context) (*sql.Tx, bool)
+func TxFromContext(ctx context.Context) *Tx
 ```
 
 Retrieve transaction from context.
 
 **Returns:**
-- `*sql.Tx` - Transaction if present
-- `bool` - `true` if transaction exists in context
+- `*Tx` - Transaction if present, or `nil`
 
 ## Context Management
 

--- a/.claude/skills/cool-mysql/references/testing-patterns.md
+++ b/.claude/skills/cool-mysql/references/testing-patterns.md
@@ -241,6 +241,76 @@ func TestTransaction(t *testing.T) {
 }
 ```
 
+### Transaction Hook Tests
+
+```go
+func TestPostCommitHooks(t *testing.T) {
+    db, mock := setupMockDB(t)
+    defer mock.ExpectClose()
+
+    mock.ExpectBegin()
+    mock.ExpectCommit()
+
+    tx, cancel, err := db.BeginTx()
+    require.NoError(t, err)
+    defer cancel()
+
+    var called bool
+    tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+        called = true
+        return nil
+    })
+
+    err = tx.Commit()
+    require.NoError(t, err)
+    require.True(t, called, "PostCommitHook should run after commit")
+}
+
+func TestPostRollbackHooks(t *testing.T) {
+    db, mock := setupMockDB(t)
+    defer mock.ExpectClose()
+
+    mock.ExpectBegin()
+    mock.ExpectRollback()
+
+    tx, _, err := db.BeginTx()
+    require.NoError(t, err)
+
+    var called bool
+    tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+        called = true
+    })
+
+    err = tx.Cancel()
+    require.NoError(t, err)
+    require.True(t, called, "PostRollbackHook should run after rollback")
+}
+
+func TestPostRollbackHooksNotRunWhenAlreadyCommitted(t *testing.T) {
+    db, mock := setupMockDB(t)
+    defer mock.ExpectClose()
+
+    mock.ExpectBegin()
+    mock.ExpectCommit()
+
+    tx, cancel, err := db.BeginTx()
+    require.NoError(t, err)
+
+    var called bool
+    tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+        called = true
+    })
+
+    err = tx.Commit()
+    require.NoError(t, err)
+
+    // defer cancel() after commit - hooks should NOT run
+    err = cancel()
+    require.NoError(t, err)
+    require.False(t, called, "PostRollbackHook should not run when tx was already committed")
+}
+```
+
 ## Test Database Setup
 
 ### Docker Compose Setup

--- a/README.md
+++ b/README.md
@@ -343,6 +343,22 @@ if err := commit(); err != nil {
 }
 ```
 
+**Transaction Hooks:**
+
+`PostCommitHooks` run after a successful commit. `PostRollbackHooks` run after a rollback (but not when `cancel()` is called on an already-committed transaction).
+
+```go
+// Clean up external state after commit
+tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+    return flush(collectors)
+})
+
+// Clean up external state if the transaction is rolled back
+tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+    collectors.Delete(tx)
+})
+```
+
 ## Advanced Features
 
 ### Context Management

--- a/tx.go
+++ b/tx.go
@@ -22,7 +22,8 @@ type Tx struct {
 		queries []string
 	}
 
-	PostCommitHooks []func() error
+	PostCommitHooks    []func() error
+	PostRollbackHooks []func()
 }
 
 type txCancelFunc func() error
@@ -108,6 +109,7 @@ func (tx *Tx) Cancel() error {
 
 	start := time.Now()
 	err := tx.Tx.Rollback()
+	rolledBack := err == nil
 	if errors.Is(err, sql.ErrTxDone) {
 		err = nil
 	}
@@ -118,6 +120,12 @@ func (tx *Tx) Cancel() error {
 		Attempt:  1,
 		Error:    err,
 	})
+
+	if rolledBack {
+		for _, hook := range tx.PostRollbackHooks {
+			hook()
+		}
+	}
 
 	return err
 }

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,0 +1,172 @@
+package mysql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostCommitHooks(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, cancel, err := db.BeginTx()
+	require.NoError(t, err)
+	defer cancel()
+
+	var called bool
+	tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+		called = true
+		return nil
+	})
+
+	err = tx.Commit()
+	require.NoError(t, err)
+	require.True(t, called, "PostCommitHook should run after commit")
+}
+
+func TestPostCommitHookErrorStopsExecution(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, cancel, err := db.BeginTx()
+	require.NoError(t, err)
+	defer cancel()
+
+	hookErr := fmt.Errorf("flush failed")
+	var secondCalled bool
+
+	tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+		return hookErr
+	})
+	tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+		secondCalled = true
+		return nil
+	})
+
+	err = tx.Commit()
+	require.Error(t, err)
+	require.ErrorIs(t, err, hookErr, "Commit should return the wrapped hook error")
+	require.Contains(t, err.Error(), "post commit hook failed")
+	require.False(t, secondCalled, "subsequent hooks should not run after a failure")
+}
+
+func TestPostCommitHooksNotRunOnRollback(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	tx, _, err := db.BeginTx()
+	require.NoError(t, err)
+
+	var called bool
+	tx.PostCommitHooks = append(tx.PostCommitHooks, func() error {
+		called = true
+		return nil
+	})
+
+	err = tx.Cancel()
+	require.NoError(t, err)
+	require.False(t, called, "PostCommitHook should not run on rollback")
+}
+
+func TestPostRollbackHooks(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	tx, _, err := db.BeginTx()
+	require.NoError(t, err)
+
+	var called bool
+	tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+		called = true
+	})
+
+	err = tx.Cancel()
+	require.NoError(t, err)
+	require.True(t, called, "PostRollbackHook should run after rollback")
+}
+
+func TestPostRollbackHooksNotRunOnCommit(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, cancel, err := db.BeginTx()
+	require.NoError(t, err)
+	defer cancel()
+
+	var called bool
+	tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+		called = true
+	})
+
+	err = tx.Commit()
+	require.NoError(t, err)
+	require.False(t, called, "PostRollbackHook should not run on commit")
+}
+
+func TestPostRollbackHooksNotRunWhenAlreadyCommitted(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, cancel, err := db.BeginTx()
+	require.NoError(t, err)
+
+	var called bool
+	tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+		called = true
+	})
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	// Cancel after commit — this is the common `defer cancel()` pattern.
+	// Rollback returns sql.ErrTxDone, so hooks should NOT run.
+	err = cancel()
+	require.NoError(t, err)
+	require.False(t, called, "PostRollbackHook should not run when tx was already committed")
+}
+
+func TestPostRollbackHooksMultiple(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	tx, _, err := db.BeginTx()
+	require.NoError(t, err)
+
+	var order []int
+	tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+		order = append(order, 1)
+	})
+	tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+		order = append(order, 2)
+	})
+	tx.PostRollbackHooks = append(tx.PostRollbackHooks, func() {
+		order = append(order, 3)
+	})
+
+	err = tx.Cancel()
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, order, "PostRollbackHooks should run in order")
+}


### PR DESCRIPTION
## Summary

- Adds `PostRollbackHooks []func()` to the `Tx` struct, analogous to the existing `PostCommitHooks`
- Hooks run after a real rollback but **not** when `cancel()` is called on an already-committed transaction (the common `defer cancel()` pattern)
- Hooks don't return errors since the transaction has already failed
- Closes #139

## Changes

- **tx.go** — Added `PostRollbackHooks` field and execution in `Cancel()`
- **tx_test.go** — 7 tests covering commit hooks, rollback hooks, error propagation, ordering, and edge cases
- **README.md, SKILL.md, api-reference.md, testing-patterns.md, transaction-patterns.go** — Updated documentation and examples

## Test plan

- [x] `TestPostCommitHooks` — commit hooks run on successful commit
- [x] `TestPostCommitHookErrorStopsExecution` — failing hook returns wrapped error, stops subsequent hooks
- [x] `TestPostCommitHooksNotRunOnRollback` — commit hooks do NOT run on rollback
- [x] `TestPostRollbackHooks` — rollback hooks run on rollback
- [x] `TestPostRollbackHooksNotRunOnCommit` — rollback hooks do NOT run on commit
- [x] `TestPostRollbackHooksNotRunWhenAlreadyCommitted` — rollback hooks do NOT run on `defer cancel()` after commit
- [x] `TestPostRollbackHooksMultiple` — multiple rollback hooks run in order
- [x] `go test ./...` passes
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)