### PR TITLE
Unwrap backoff.PermanentError before returning (#142)

### DIFF
--- a/backoff_permanent_test.go
+++ b/backoff_permanent_test.go
@@ -1,0 +1,69 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/cenkalti/backoff/v5"
+)
+
+// failingQueryHandler returns the configured error on QueryContext and panics
+// on ExecContext, mirroring the failingExecHandler pattern but for the
+// read-path APIs (exists, select).
+type failingQueryHandler struct {
+	err error
+}
+
+func (h *failingQueryHandler) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	panic("unexpected ExecContext call in failingQueryHandler")
+}
+
+func (h *failingQueryHandler) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return nil, h.err
+}
+
+// errPermanentProbe is a sentinel distinct from any error cool-mysql treats as
+// retryable or as an invalid-connection signal, so it's guaranteed to hit the
+// backoff.Permanent branch in exec/exists/select.
+var errPermanentProbe = errors.New("permanent probe error")
+
+func assertNoPermanentWrapper(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var perm *backoff.PermanentError
+	if errors.As(err, &perm) {
+		t.Fatalf("returned error chain still contains *backoff.PermanentError: %#v", err)
+	}
+	if !errors.Is(err, errPermanentProbe) {
+		t.Fatalf("returned error should unwrap to errPermanentProbe, got %v", err)
+	}
+}
+
+func TestExecDoesNotLeakPermanentError(t *testing.T) {
+	h := &failingExecHandler{errors: []error{errPermanentProbe}}
+
+	db := &Database{}
+	_, err := db.exec(h, context.Background(), nil, true, "SELECT 1")
+	assertNoPermanentWrapper(t, err)
+}
+
+func TestExistsDoesNotLeakPermanentError(t *testing.T) {
+	h := &failingQueryHandler{err: errPermanentProbe}
+
+	db := &Database{Logger: DefaultLogger()}
+	_, err := db.exists(h, context.Background(), "SELECT 1", 0)
+	assertNoPermanentWrapper(t, err)
+}
+
+func TestSelectDoesNotLeakPermanentError(t *testing.T) {
+	h := &failingQueryHandler{err: errPermanentProbe}
+
+	db := &Database{Logger: DefaultLogger()}
+	var out []int
+	err := db.query(h, context.Background(), &out, "SELECT 1", 0)
+	assertNoPermanentWrapper(t, err)
+}

--- a/error.go
+++ b/error.go
@@ -5,8 +5,21 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cenkalti/backoff/v5"
 	stdMysql "github.com/go-sql-driver/mysql"
 )
+
+// unwrapBackoffPermanent strips any *backoff.PermanentError wrapper from the
+// error chain. backoff.Permanent is used internally to signal "don't retry" to
+// backoff.Retry; it must never leak into the public error surface because it
+// would hijack any outer backoff.Retry loop a caller builds around us.
+func unwrapBackoffPermanent(err error) error {
+	var p *backoff.PermanentError
+	if errors.As(err, &p) {
+		return p.Err
+	}
+	return err
+}
 
 // Error contains the error and query details
 type Error struct {

--- a/exec.go
+++ b/exec.go
@@ -111,7 +111,7 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 	res, err = backoff.Retry(ctx, operation, options...)
 	if err != nil {
 		return nil, Error{
-			Err:           err,
+			Err:           unwrapBackoffPermanent(err),
 			OriginalQuery: query,
 			ReplacedQuery: replacedQuery,
 			Params:        normalizedParams,

--- a/exists.go
+++ b/exists.go
@@ -141,7 +141,7 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 
 	rows, err := backoff.Retry(ctx, operation, options...)
 	if err != nil {
-		return exists, err
+		return exists, unwrapBackoffPermanent(err)
 	}
 	defer func() {
 		if rows != nil {

--- a/select.go
+++ b/select.go
@@ -243,7 +243,7 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 
 	rows, err := backoff.Retry(ctx, operation, options...)
 	if err != nil {
-		return err
+		return unwrapBackoffPermanent(err)
 	}
 
 	if rows == nil {


### PR DESCRIPTION
## Summary
- Keeps `backoff.Permanent` purely as an internal control-flow signal — strips the `*backoff.PermanentError` wrapper at each `backoff.Retry` return site in `exec`, `exists`, and `select`.
- Callers still see the underlying driver error (`*mysql.MySQLError`, `sql.ErrNoRows`, etc.) via `errors.Is` / `errors.As`, but no longer see the internal wrapper — so outer `backoff.Retry` loops built around cool-mysql behave correctly.
- Fixes #142.

## Test plan
- [x] `go test ./...` passes
- [x] New `backoff_permanent_test.go` covers exec, exists, and select — asserts the returned error chain no longer contains `*backoff.PermanentError` and still unwraps to the original sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)