### PR TITLE
Add NewFromDSNDualPool for two pools against a single DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,20 @@ err := db.Insert("users", newUser)
 err := db.SelectWrites(&users, "SELECT * FROM users WHERE just_created = 1", nil)
 ```
 
+**Single DSN, two pools.** `NewFromDSN(dsn, dsn)` with identical strings
+collapses to one shared pool — fine for short-lived callers (Lambda,
+scripts) but can cause reads/writes contention under concurrent load for
+long-running tools. When you don't have a read replica but still want two
+independent pools, use `NewFromDSNDualPool(dsn)`:
+
+```go
+// One pool shared by Reads and Writes
+db, err := mysql.NewFromDSN(dsn, dsn)
+
+// Two independent pools against the same DSN
+db, err := mysql.NewFromDSNDualPool(dsn)
+```
+
 ### Large Dataset Handling
 
 **Chunked inserts** automatically respect MySQL's `max_allowed_packet`:

--- a/database.go
+++ b/database.go
@@ -190,12 +190,17 @@ func New(wUser, wPass, wSchema, wHost string, wPort int,
 	return NewFromDSN(writes.FormatDSN(), reads.FormatDSN())
 }
 
+// sqlOpenFunc is the function openPool uses to open a *sql.DB. It's a
+// package-level variable so tests can substitute a fake that returns a
+// sqlmock-backed pool instead of hitting a real MySQL server.
+var sqlOpenFunc = sql.Open
+
 // openPool opens a MySQL pool against the given DSN, pings it, applies the
 // session timezone, and configures the connection lifetime. On any error
 // after Open the pool is closed so the caller doesn't have to. connType is
 // used only in error messages (e.g. "writes", "reads").
 func openPool(dsn, connType string) (*sql.DB, error) {
-	conn, err := sql.Open("mysql", dsn)
+	conn, err := sqlOpenFunc("mysql", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/database.go
+++ b/database.go
@@ -201,14 +201,14 @@ func openPool(dsn, connType string) (*sql.DB, error) {
 	}
 
 	if err := conn.Ping(); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 
 	// Set MySQL session timezone to match the Go driver's Loc parameter
 	// so timestamps returned by MySQL are interpreted correctly.
 	if err := setSessionTimezone(conn, dsn, connType); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 
@@ -238,7 +238,7 @@ func NewFromDSN(writes, reads string) (db *Database, err error) {
 
 	writesDSN, err := mysql.ParseDSN(writes)
 	if err != nil {
-		writesConn.Close()
+		_ = writesConn.Close()
 		return nil, fmt.Errorf("failed to parse writes DSN: %w", err)
 	}
 	db.MaxInsertSize = new(synct[int])
@@ -247,7 +247,7 @@ func NewFromDSN(writes, reads string) (db *Database, err error) {
 	if reads != writes {
 		readsConn, err := openPool(reads, "reads")
 		if err != nil {
-			writesConn.Close()
+			_ = writesConn.Close()
 			return nil, err
 		}
 		db.ReadsDSN = reads
@@ -283,7 +283,7 @@ func NewFromDSNDualPool(dsn string) (db *Database, err error) {
 
 	parsed, err := mysql.ParseDSN(dsn)
 	if err != nil {
-		writesConn.Close()
+		_ = writesConn.Close()
 		return nil, fmt.Errorf("failed to parse DSN: %w", err)
 	}
 	db.MaxInsertSize = new(synct[int])
@@ -291,7 +291,7 @@ func NewFromDSNDualPool(dsn string) (db *Database, err error) {
 
 	readsConn, err := openPool(dsn, "reads")
 	if err != nil {
-		writesConn.Close()
+		_ = writesConn.Close()
 		return nil, err
 	}
 	db.ReadsDSN = dsn

--- a/database.go
+++ b/database.go
@@ -49,6 +49,12 @@ type Database struct {
 
 	tmplFuncs   template.FuncMap
 	valuerFuncs map[reflect.Type]reflect.Value
+
+	// forceDualPool, when set, tells Reconnect to rebuild two independent
+	// pools from WritesDSN even if WritesDSN == ReadsDSN. Set by
+	// NewFromDSNDualPool. Not exported; external callers should pick the
+	// constructor that matches their intent.
+	forceDualPool bool
 }
 
 // Clone returns a copy of the db with the same connections
@@ -184,67 +190,114 @@ func New(wUser, wPass, wSchema, wHost string, wPort int,
 	return NewFromDSN(writes.FormatDSN(), reads.FormatDSN())
 }
 
-// NewFromDSN creates a new Database from config
-// DSN strings for both connections
+// openPool opens a MySQL pool against the given DSN, pings it, applies the
+// session timezone, and configures the connection lifetime. On any error
+// after Open the pool is closed so the caller doesn't have to. connType is
+// used only in error messages (e.g. "writes", "reads").
+func openPool(dsn, connType string) (*sql.DB, error) {
+	conn, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := conn.Ping(); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// Set MySQL session timezone to match the Go driver's Loc parameter
+	// so timestamps returned by MySQL are interpreted correctly.
+	if err := setSessionTimezone(conn, dsn, connType); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	conn.SetConnMaxLifetime(MaxConnectionTime)
+	return conn, nil
+}
+
+// NewFromDSN creates a new Database from DSN strings for the writes and
+// reads connections.
+//
+// If writes == reads (same string), Reads and Writes share a single
+// *sql.DB pool — useful for callers without a read replica who are fine
+// with one pool. If you want two independent pools against the same DSN
+// (to avoid reads and writes contending for connections under concurrent
+// load), use NewFromDSNDualPool instead.
 func NewFromDSN(writes, reads string) (db *Database, err error) {
 	db = new(Database)
 	db.testMx = new(sync.Mutex)
+	db.Logger = DefaultLogger()
 
+	writesConn, err := openPool(writes, "writes")
+	if err != nil {
+		return nil, err
+	}
 	db.WritesDSN = writes
-	var writesConn *sql.DB
-	writesConn, err = sql.Open("mysql", writes)
-	if err != nil {
-		return nil, err
-	}
-
-	err = writesConn.Ping()
-	if err != nil {
-		return nil, err
-	}
+	db.Writes = writesConn
 
 	writesDSN, err := mysql.ParseDSN(writes)
 	if err != nil {
+		writesConn.Close()
 		return nil, fmt.Errorf("failed to parse writes DSN: %w", err)
 	}
 	db.MaxInsertSize = new(synct[int])
 	db.MaxInsertSize.Set(writesDSN.MaxAllowedPacket)
 
-	// Set MySQL session timezone to match the Go driver's Loc parameter
-	// This ensures timestamps returned by MySQL are interpreted correctly
-	if err := setSessionTimezone(writesConn, writes, "writes"); err != nil {
-		return nil, err
-	}
-
-	writesConn.SetConnMaxLifetime(MaxConnectionTime)
-
-	db.Writes = writesConn
-
 	if reads != writes {
+		readsConn, err := openPool(reads, "reads")
+		if err != nil {
+			writesConn.Close()
+			return nil, err
+		}
 		db.ReadsDSN = reads
-		db.Reads, err = sql.Open("mysql", reads)
-		if err != nil {
-			return nil, err
-		}
-
-		err = db.Reads.Ping()
-		if err != nil {
-			return nil, err
-		}
-
-		// Set MySQL session timezone on reads connection as well
-		if err := setSessionTimezone(db.Reads, reads, "reads"); err != nil {
-			return nil, err
-		}
-
-		db.Reads.SetConnMaxLifetime(MaxConnectionTime)
+		db.Reads = readsConn
 	} else {
 		db.ReadsDSN = writes
 		db.Reads = writesConn
 	}
 
-	db.Logger = DefaultLogger()
+	return db, nil
+}
 
-	return db, err
+// NewFromDSNDualPool creates a new Database with two independent
+// connection pools backed by the same DSN.
+//
+// Use this when you don't have a read replica but still want Reads and
+// Writes to use separate pools. The dual-pool design exists to keep reads
+// and writes from starving each other under concurrent load, which is
+// defeated by NewFromDSN(dsn, dsn) because equal DSN strings collapse to
+// a single shared pool.
+func NewFromDSNDualPool(dsn string) (db *Database, err error) {
+	db = new(Database)
+	db.testMx = new(sync.Mutex)
+	db.Logger = DefaultLogger()
+	db.forceDualPool = true
+
+	writesConn, err := openPool(dsn, "writes")
+	if err != nil {
+		return nil, err
+	}
+	db.WritesDSN = dsn
+	db.Writes = writesConn
+
+	parsed, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		writesConn.Close()
+		return nil, fmt.Errorf("failed to parse DSN: %w", err)
+	}
+	db.MaxInsertSize = new(synct[int])
+	db.MaxInsertSize.Set(parsed.MaxAllowedPacket)
+
+	readsConn, err := openPool(dsn, "reads")
+	if err != nil {
+		writesConn.Close()
+		return nil, err
+	}
+	db.ReadsDSN = dsn
+	db.Reads = readsConn
+
+	return db, nil
 }
 
 // NewFromConn creates a new Database given existing *sql.DB connections.
@@ -375,13 +428,19 @@ func (db *Database) Close() error {
 // Reconnect creates new connection(s) for writes and reads
 // and replaces the existing connections with the new ones
 func (db *Database) Reconnect() error {
-	new, err := NewFromDSN(db.WritesDSN, db.ReadsDSN)
+	var fresh *Database
+	var err error
+	if db.forceDualPool {
+		fresh, err = NewFromDSNDualPool(db.WritesDSN)
+	} else {
+		fresh, err = NewFromDSN(db.WritesDSN, db.ReadsDSN)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to reconnect: %w", err)
 	}
 
-	db.Writes = new.Writes
-	db.Reads = new.Reads
+	db.Writes = fresh.Writes
+	db.Reads = fresh.Reads
 
 	return nil
 }

--- a/database.go
+++ b/database.go
@@ -431,7 +431,11 @@ func (db *Database) Close() error {
 }
 
 // Reconnect creates new connection(s) for writes and reads
-// and replaces the existing connections with the new ones
+// and replaces the existing connections with the new ones.
+// The old pools are closed before being replaced; any close error
+// is logged as a warning rather than returned, because Reconnect is
+// typically called when the old pools are already broken and the new
+// ones are what the caller needs to move forward with.
 func (db *Database) Reconnect() error {
 	var fresh *Database
 	var err error
@@ -442,6 +446,10 @@ func (db *Database) Reconnect() error {
 	}
 	if err != nil {
 		return fmt.Errorf("failed to reconnect: %w", err)
+	}
+
+	if closeErr := db.Close(); closeErr != nil {
+		db.Logger.Warn("failed to close old pools during reconnect", "err", closeErr)
 	}
 
 	db.Writes = fresh.Writes

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,187 @@
+package mysql
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+// The DSN value we feed the constructors in these tests. It only has to
+// parse under github.com/go-sql-driver/mysql — sqlOpenFunc is swapped to
+// return sqlmock pools, so the DSN is never dialed.
+const testDSN = "user:pass@tcp(localhost:3306)/db"
+
+type mockOpen struct {
+	calls int
+	pools []*sql.DB
+	mocks []sqlmock.Sqlmock
+}
+
+// installMockOpen replaces sqlOpenFunc for the duration of a test with a
+// fake that hands back sqlmock pools. Every returned mock pre-expects the
+// "SET time_zone = ?" that setSessionTimezone always emits (the go-sql
+// driver's ParseDSN defaults Loc to UTC, so the call is unconditional).
+// The caller can push additional expectations onto mo.mocks[i] after the
+// constructor runs.
+func installMockOpen(t *testing.T) *mockOpen {
+	t.Helper()
+
+	original := sqlOpenFunc
+	mo := &mockOpen{}
+
+	sqlOpenFunc = func(driver, dsn string) (*sql.DB, error) {
+		if driver != "mysql" {
+			return nil, errors.New("unexpected driver: " + driver)
+		}
+		pool, m, err := sqlmock.New()
+		if err != nil {
+			return nil, err
+		}
+		// setSessionTimezone runs unconditionally because ParseDSN
+		// populates Loc with time.UTC by default.
+		m.ExpectExec(`SET time_zone = \?`).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mo.calls++
+		mo.pools = append(mo.pools, pool)
+		mo.mocks = append(mo.mocks, m)
+		return pool, nil
+	}
+
+	t.Cleanup(func() {
+		sqlOpenFunc = original
+		for _, p := range mo.pools {
+			_ = p.Close()
+		}
+	})
+
+	return mo
+}
+
+func writesPool(t *testing.T, db *Database) *sql.DB {
+	t.Helper()
+	p, ok := db.Writes.(*sql.DB)
+	require.True(t, ok, "db.Writes is not a *sql.DB")
+	return p
+}
+
+func TestNewFromDSN_SameDSNSharesOnePool(t *testing.T) {
+	mo := installMockOpen(t)
+
+	db, err := NewFromDSN(testDSN, testDSN)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, mo.calls, "same DSN should open exactly one pool")
+	require.Same(t, writesPool(t, db), db.Reads, "Reads and Writes must share a pool")
+	require.False(t, db.forceDualPool)
+	require.Equal(t, testDSN, db.WritesDSN)
+	require.Equal(t, testDSN, db.ReadsDSN)
+}
+
+func TestNewFromDSN_DistinctDSNsOpenTwoPools(t *testing.T) {
+	mo := installMockOpen(t)
+
+	writesDSN := testDSN
+	readsDSN := "user:pass@tcp(replica:3306)/db"
+	db, err := NewFromDSN(writesDSN, readsDSN)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, mo.calls)
+	require.NotSame(t, writesPool(t, db), db.Reads, "distinct DSNs must open distinct pools")
+	require.False(t, db.forceDualPool)
+	require.Equal(t, writesDSN, db.WritesDSN)
+	require.Equal(t, readsDSN, db.ReadsDSN)
+}
+
+func TestNewFromDSNDualPool_OpensTwoDistinctPools(t *testing.T) {
+	mo := installMockOpen(t)
+
+	db, err := NewFromDSNDualPool(testDSN)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, mo.calls, "dual-pool must open two pools even for the same DSN")
+	require.NotSame(t, writesPool(t, db), db.Reads)
+	require.True(t, db.forceDualPool)
+	require.Equal(t, testDSN, db.WritesDSN)
+	require.Equal(t, testDSN, db.ReadsDSN)
+	require.NotNil(t, db.MaxInsertSize)
+}
+
+func TestReconnect_PreservesDualPool(t *testing.T) {
+	mo := installMockOpen(t)
+
+	db, err := NewFromDSNDualPool(testDSN)
+	require.NoError(t, err)
+	require.Equal(t, 2, mo.calls)
+
+	require.NoError(t, db.Reconnect())
+	require.Equal(t, 4, mo.calls, "Reconnect on a dual-pool db must open two new pools")
+	require.NotSame(t, writesPool(t, db), db.Reads, "Reconnect must not collapse to one pool")
+}
+
+func TestReconnect_SharedPoolStaysShared(t *testing.T) {
+	mo := installMockOpen(t)
+
+	db, err := NewFromDSN(testDSN, testDSN)
+	require.NoError(t, err)
+	require.Equal(t, 1, mo.calls)
+
+	require.NoError(t, db.Reconnect())
+	require.Equal(t, 2, mo.calls, "Reconnect on a shared-pool db should only open one new pool")
+	require.Same(t, writesPool(t, db), db.Reads)
+}
+
+func TestOpenPool_PingFailureClosesPool(t *testing.T) {
+	original := sqlOpenFunc
+	t.Cleanup(func() { sqlOpenFunc = original })
+
+	var capturedMock sqlmock.Sqlmock
+	pingErr := errors.New("boom")
+	sqlOpenFunc = func(driver, dsn string) (*sql.DB, error) {
+		pool, m, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+		if err != nil {
+			return nil, err
+		}
+		m.ExpectPing().WillReturnError(pingErr)
+		m.ExpectClose()
+		capturedMock = m
+		return pool, nil
+	}
+
+	_, err := openPool(testDSN, "writes")
+	require.ErrorIs(t, err, pingErr)
+	// ExpectClose on the mock asserts openPool closed the pool on error.
+	require.NoError(t, capturedMock.ExpectationsWereMet())
+}
+
+func TestNewFromDSNDualPool_ReadsOpenFailureClosesWrites(t *testing.T) {
+	original := sqlOpenFunc
+	t.Cleanup(func() { sqlOpenFunc = original })
+
+	openErr := errors.New("second open failed")
+	var writesMock sqlmock.Sqlmock
+	var call int
+	sqlOpenFunc = func(driver, dsn string) (*sql.DB, error) {
+		call++
+		if call == 1 {
+			pool, m, err := sqlmock.New()
+			if err != nil {
+				return nil, err
+			}
+			m.ExpectExec(`SET time_zone = \?`).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+			// After the reads-side open fails below, the constructor
+			// must close the writes pool it already opened.
+			m.ExpectClose()
+			writesMock = m
+			return pool, nil
+		}
+		return nil, openErr
+	}
+
+	_, err := NewFromDSNDualPool(testDSN)
+	require.ErrorIs(t, err, openErr)
+	require.NoError(t, writesMock.ExpectationsWereMet())
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -115,10 +115,15 @@ func TestReconnect_PreservesDualPool(t *testing.T) {
 	db, err := NewFromDSNDualPool(testDSN)
 	require.NoError(t, err)
 	require.Equal(t, 2, mo.calls)
+	// Expect the two original pools to be closed when Reconnect swaps.
+	mo.mocks[0].ExpectClose()
+	mo.mocks[1].ExpectClose()
 
 	require.NoError(t, db.Reconnect())
 	require.Equal(t, 4, mo.calls, "Reconnect on a dual-pool db must open two new pools")
 	require.NotSame(t, writesPool(t, db), db.Reads, "Reconnect must not collapse to one pool")
+	require.NoError(t, mo.mocks[0].ExpectationsWereMet())
+	require.NoError(t, mo.mocks[1].ExpectationsWereMet())
 }
 
 func TestReconnect_SharedPoolStaysShared(t *testing.T) {
@@ -127,10 +132,13 @@ func TestReconnect_SharedPoolStaysShared(t *testing.T) {
 	db, err := NewFromDSN(testDSN, testDSN)
 	require.NoError(t, err)
 	require.Equal(t, 1, mo.calls)
+	// The single shared old pool must be closed exactly once.
+	mo.mocks[0].ExpectClose()
 
 	require.NoError(t, db.Reconnect())
 	require.Equal(t, 2, mo.calls, "Reconnect on a shared-pool db should only open one new pool")
 	require.Same(t, writesPool(t, db), db.Reads)
+	require.NoError(t, mo.mocks[0].ExpectationsWereMet())
 }
 
 func TestOpenPool_PingFailureClosesPool(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `NewFromDSNDualPool(dsn string)` — opens two independent pools against the same DSN, fixing the silent collapse when `NewFromDSN(dsn, dsn)` is called with identical strings.
- Factors `sql.Open` + Ping + session timezone + `SetConnMaxLifetime` into an `openPool` helper and reuses it from both `NewFromDSN` and `NewFromDSNDualPool`. Cleanup on partial-failure paths now closes the already-opened pool.
- `Reconnect` tracks which constructor built the Database (`forceDualPool` flag) so a dual-pool setup survives reconnects instead of silently collapsing back to one pool.
- README gets a short "Single DSN, two pools" paragraph pointing callers without a read replica at the new constructor.

Closes #146.

## Test plan

- [x] `go test ./...` — passes
- [x] `golangci-lint run ./...` — clean
- [ ] Manually exercise `NewFromDSNDualPool` against a real MySQL and confirm two distinct pools (not covered by unit tests — the existing harness is sqlmock-based and can't drive `sql.Open("mysql", ...)`; `NewFromDSN` has the same test gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)