### PR TITLE
Make MaxExecutionTime and MaxConnectionTime per-Database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Template branches (`{{ if .Name }}...`) look up the **Go field name**, not the `
 
 | Var | Default | Effect |
 |---|---|---|
-| `COOL_MAX_EXECUTION_TIME_TIME` | 27s | Total retry budget per query (also sets `SetConnMaxLifetime`) |
+| `COOL_MAX_EXECUTION_TIME_TIME` | 27s | Seeds `MaxExecutionTime` (the retry budget per query) and `MaxConnectionTime` (`SetConnMaxLifetime`). Both are copied onto `*Database.MaxExecutionTime` / `.MaxConnectionTime` at construction — set the field (or call `SetMaxConnectionTime`) per instance to override for long-running processes. |
 | `COOL_MAX_ATTEMPTS` | 0 (uncapped) | Hard cap on retry attempts |
 | `COOL_REDIS_LOCK_RETRY_DELAY` | 20ms | Redis-backed `Locker` poll interval |
 | `COOL_MYSQL_MAX_QUERY_LOG_LENGTH` | 4096 | Truncation point for query text in `Error.Error()` |

--- a/database.go
+++ b/database.go
@@ -36,6 +36,20 @@ type Database struct {
 
 	MaxInsertSize *synct[int]
 
+	// MaxExecutionTime caps the total time (including retries) a single
+	// query is allowed to run before giving up. Zero means no cap.
+	// Initialized from the package-level MaxExecutionTime var (Lambda-
+	// oriented 27s default); long-running processes should set this to 0
+	// or a larger value that matches their workload.
+	MaxExecutionTime time.Duration
+
+	// MaxConnectionTime is the SetConnMaxLifetime value applied to both
+	// pools at construction. Zero means connections are reused forever.
+	// Initialized from the package-level MaxConnectionTime var. Change at
+	// runtime with SetMaxConnectionTime so the underlying pools pick up
+	// the new value.
+	MaxConnectionTime time.Duration
+
 	cache  Cache
 	locker Locker
 
@@ -198,8 +212,9 @@ var sqlOpenFunc = sql.Open
 // openPool opens a MySQL pool against the given DSN, pings it, applies the
 // session timezone, and configures the connection lifetime. On any error
 // after Open the pool is closed so the caller doesn't have to. connType is
-// used only in error messages (e.g. "writes", "reads").
-func openPool(dsn, connType string) (*sql.DB, error) {
+// used only in error messages (e.g. "writes", "reads"). connMaxLifetime
+// is passed straight to SetConnMaxLifetime — zero means "reuse forever".
+func openPool(dsn, connType string, connMaxLifetime time.Duration) (*sql.DB, error) {
 	conn, err := sqlOpenFunc("mysql", dsn)
 	if err != nil {
 		return nil, err
@@ -217,7 +232,7 @@ func openPool(dsn, connType string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	conn.SetConnMaxLifetime(MaxConnectionTime)
+	conn.SetConnMaxLifetime(connMaxLifetime)
 	return conn, nil
 }
 
@@ -233,8 +248,10 @@ func NewFromDSN(writes, reads string) (db *Database, err error) {
 	db = new(Database)
 	db.testMx = new(sync.Mutex)
 	db.Logger = DefaultLogger()
+	db.MaxExecutionTime = MaxExecutionTime
+	db.MaxConnectionTime = MaxConnectionTime
 
-	writesConn, err := openPool(writes, "writes")
+	writesConn, err := openPool(writes, "writes", db.MaxConnectionTime)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +267,7 @@ func NewFromDSN(writes, reads string) (db *Database, err error) {
 	db.MaxInsertSize.Set(writesDSN.MaxAllowedPacket)
 
 	if reads != writes {
-		readsConn, err := openPool(reads, "reads")
+		readsConn, err := openPool(reads, "reads", db.MaxConnectionTime)
 		if err != nil {
 			_ = writesConn.Close()
 			return nil, err
@@ -278,8 +295,10 @@ func NewFromDSNDualPool(dsn string) (db *Database, err error) {
 	db.testMx = new(sync.Mutex)
 	db.Logger = DefaultLogger()
 	db.forceDualPool = true
+	db.MaxExecutionTime = MaxExecutionTime
+	db.MaxConnectionTime = MaxConnectionTime
 
-	writesConn, err := openPool(dsn, "writes")
+	writesConn, err := openPool(dsn, "writes", db.MaxConnectionTime)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +313,7 @@ func NewFromDSNDualPool(dsn string) (db *Database, err error) {
 	db.MaxInsertSize = new(synct[int])
 	db.MaxInsertSize.Set(parsed.MaxAllowedPacket)
 
-	readsConn, err := openPool(dsn, "reads")
+	readsConn, err := openPool(dsn, "reads", db.MaxConnectionTime)
 	if err != nil {
 		_ = writesConn.Close()
 		return nil, err
@@ -311,6 +330,8 @@ func NewFromDSNDualPool(dsn string) (db *Database, err error) {
 func NewFromConn(writesConn, readsConn *sql.DB) (*Database, error) {
 	db := new(Database)
 	db.testMx = new(sync.Mutex)
+	db.MaxExecutionTime = MaxExecutionTime
+	db.MaxConnectionTime = MaxConnectionTime
 
 	// 1) Pull the server's max_allowed_packet value
 	var maxPacket int64
@@ -325,7 +346,7 @@ func NewFromConn(writesConn, readsConn *sql.DB) (*Database, error) {
 	// 2) Wire up Writes
 	db.Writes = writesConn
 	db.WritesDSN = "" // not known from *sql.DB
-	writesConn.SetConnMaxLifetime(MaxConnectionTime)
+	writesConn.SetConnMaxLifetime(db.MaxConnectionTime)
 
 	// 3) Wire up Reads (may be same as Writes)
 	db.Reads = readsConn
@@ -333,7 +354,7 @@ func NewFromConn(writesConn, readsConn *sql.DB) (*Database, error) {
 		db.ReadsDSN = ""
 	} else {
 		db.ReadsDSN = ""
-		readsConn.SetConnMaxLifetime(MaxConnectionTime)
+		readsConn.SetConnMaxLifetime(db.MaxConnectionTime)
 	}
 
 	// 4) Logger setup (identical to NewFromDSN)
@@ -352,6 +373,8 @@ func NewLocalWriter(path string) (*Database, error) {
 	db.Writes = sqlWriter
 
 	db.testMx = new(sync.Mutex)
+	db.MaxExecutionTime = MaxExecutionTime
+	db.MaxConnectionTime = MaxConnectionTime
 
 	db.MaxInsertSize = new(synct[int])
 	db.MaxInsertSize.Set(1 << 20)
@@ -369,6 +392,8 @@ func NewWriter(w io.Writer) (*Database, error) {
 	db.Writes = writer
 
 	db.testMx = new(sync.Mutex)
+	db.MaxExecutionTime = MaxExecutionTime
+	db.MaxConnectionTime = MaxConnectionTime
 
 	db.MaxInsertSize = new(synct[int])
 	db.MaxInsertSize.Set(1 << 20)
@@ -376,6 +401,21 @@ func NewWriter(w io.Writer) (*Database, error) {
 	db.Logger = DefaultLogger()
 
 	return db, nil
+}
+
+// SetMaxConnectionTime updates db.MaxConnectionTime and applies the new
+// value to the underlying write and read pools via SetConnMaxLifetime.
+// Pass 0 for "reuse connections forever". Assigning the field directly
+// won't affect already-opened pools — go through this setter to take
+// effect at runtime.
+func (db *Database) SetMaxConnectionTime(d time.Duration) {
+	db.MaxConnectionTime = d
+	if w, ok := db.Writes.(*sql.DB); ok {
+		w.SetConnMaxLifetime(d)
+	}
+	if db.Reads != nil {
+		db.Reads.SetConnMaxLifetime(d)
+	}
 }
 
 // AddTemplateFuncs adds template functions to the database
@@ -436,6 +476,11 @@ func (db *Database) Close() error {
 // is logged as a warning rather than returned, because Reconnect is
 // typically called when the old pools are already broken and the new
 // ones are what the caller needs to move forward with.
+//
+// Any per-instance overrides to MaxConnectionTime are re-applied to
+// the new pools. The fresh Database built by the constructors
+// otherwise carries the package-level defaults, which would silently
+// revert an override set via SetMaxConnectionTime.
 func (db *Database) Reconnect() error {
 	var fresh *Database
 	var err error
@@ -454,6 +499,13 @@ func (db *Database) Reconnect() error {
 
 	db.Writes = fresh.Writes
 	db.Reads = fresh.Reads
+
+	if freshW, ok := fresh.Writes.(*sql.DB); ok {
+		freshW.SetConnMaxLifetime(db.MaxConnectionTime)
+	}
+	if fresh.Reads != nil && fresh.Reads != fresh.Writes {
+		fresh.Reads.SetConnMaxLifetime(db.MaxConnectionTime)
+	}
 
 	return nil
 }

--- a/exec.go
+++ b/exec.go
@@ -102,7 +102,7 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 
 	options := []backoff.RetryOption{
 		backoff.WithBackOff(b),
-		backoff.WithMaxElapsedTime(MaxExecutionTime),
+		backoff.WithMaxElapsedTime(db.MaxExecutionTime),
 	}
 	if MaxAttempts > 0 {
 		options = append(options, backoff.WithMaxTries(uint(MaxAttempts)))

--- a/execution_time_test.go
+++ b/execution_time_test.go
@@ -1,0 +1,235 @@
+package mysql
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func withPackageExecTimes(t *testing.T, exec, conn time.Duration) {
+	t.Helper()
+	origExec := MaxExecutionTime
+	origConn := MaxConnectionTime
+	MaxExecutionTime = exec
+	MaxConnectionTime = conn
+	t.Cleanup(func() {
+		MaxExecutionTime = origExec
+		MaxConnectionTime = origConn
+	})
+}
+
+func TestNewFromDSN_SeedsExecutionTimeFields(t *testing.T) {
+	installMockOpen(t)
+	withPackageExecTimes(t, 11*time.Second, 13*time.Second)
+
+	db, err := NewFromDSN(testDSN, testDSN)
+	require.NoError(t, err)
+	require.Equal(t, 11*time.Second, db.MaxExecutionTime)
+	require.Equal(t, 13*time.Second, db.MaxConnectionTime)
+}
+
+func TestNewFromDSN_DistinctDSN_SeedsExecutionTimeFields(t *testing.T) {
+	installMockOpen(t)
+	withPackageExecTimes(t, 7*time.Second, 9*time.Second)
+
+	db, err := NewFromDSN(testDSN, "user:pass@tcp(replica:3306)/db")
+	require.NoError(t, err)
+	require.Equal(t, 7*time.Second, db.MaxExecutionTime)
+	require.Equal(t, 9*time.Second, db.MaxConnectionTime)
+}
+
+func TestNewFromDSNDualPool_SeedsExecutionTimeFields(t *testing.T) {
+	installMockOpen(t)
+	withPackageExecTimes(t, 5*time.Second, 3*time.Second)
+
+	db, err := NewFromDSNDualPool(testDSN)
+	require.NoError(t, err)
+	require.Equal(t, 5*time.Second, db.MaxExecutionTime)
+	require.Equal(t, 3*time.Second, db.MaxConnectionTime)
+}
+
+func TestNewFromConn_SeedsExecutionTimeFields(t *testing.T) {
+	withPackageExecTimes(t, 19*time.Second, 23*time.Second)
+
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	mock.ExpectQuery(`^SELECT @@max_allowed_packet$`).
+		WillReturnRows(sqlmock.NewRows([]string{"@@max_allowed_packet"}).AddRow(int64(4194304)))
+
+	db, err := NewFromConn(mockDB, mockDB)
+	require.NoError(t, err)
+	require.Equal(t, 19*time.Second, db.MaxExecutionTime)
+	require.Equal(t, 23*time.Second, db.MaxConnectionTime)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestNewFromConn_DistinctPools_SeedsExecutionTimeFields(t *testing.T) {
+	withPackageExecTimes(t, 2*time.Second, 4*time.Second)
+
+	writesDB, writesMock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writesDB.Close() })
+	readsDB, _, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = readsDB.Close() })
+
+	writesMock.ExpectQuery(`^SELECT @@max_allowed_packet$`).
+		WillReturnRows(sqlmock.NewRows([]string{"@@max_allowed_packet"}).AddRow(int64(4194304)))
+
+	db, err := NewFromConn(writesDB, readsDB)
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Second, db.MaxExecutionTime)
+	require.Equal(t, 4*time.Second, db.MaxConnectionTime)
+	require.NotSame(t, db.Writes, db.Reads, "distinct conns must remain distinct")
+}
+
+func TestSetMaxConnectionTime_UpdatesFieldAndPools(t *testing.T) {
+	installMockOpen(t)
+
+	db, err := NewFromDSNDualPool(testDSN)
+	require.NoError(t, err)
+
+	// Sanity: two independent pools so the setter has both branches to walk.
+	require.NotSame(t, writesPool(t, db), db.Reads)
+
+	db.SetMaxConnectionTime(42 * time.Second)
+	require.Equal(t, 42*time.Second, db.MaxConnectionTime)
+
+	db.SetMaxConnectionTime(0)
+	require.Equal(t, time.Duration(0), db.MaxConnectionTime)
+}
+
+func TestSetMaxConnectionTime_NonDBWrites_NilReads(t *testing.T) {
+	// Cover the branches where Writes isn't a *sql.DB (e.g. NewWriter)
+	// and Reads is nil.
+	db, err := NewWriter(&bytes.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, db.Reads)
+	_, isSQLDB := db.Writes.(*sql.DB)
+	require.False(t, isSQLDB)
+
+	db.SetMaxConnectionTime(5 * time.Second)
+	require.Equal(t, 5*time.Second, db.MaxConnectionTime)
+}
+
+func TestNewWriter_SeedsExecutionTimeFields(t *testing.T) {
+	withPackageExecTimes(t, 6*time.Second, 8*time.Second)
+
+	db, err := NewWriter(&bytes.Buffer{})
+	require.NoError(t, err)
+	require.Equal(t, 6*time.Second, db.MaxExecutionTime)
+	require.Equal(t, 8*time.Second, db.MaxConnectionTime)
+}
+
+func TestNewLocalWriter_SeedsExecutionTimeFields(t *testing.T) {
+	withPackageExecTimes(t, 17*time.Second, 21*time.Second)
+
+	db, err := NewLocalWriter(t.TempDir())
+	require.NoError(t, err)
+	require.Equal(t, 17*time.Second, db.MaxExecutionTime)
+	require.Equal(t, 21*time.Second, db.MaxConnectionTime)
+}
+
+func TestReconnect_PreservesMaxConnectionTimeOverride(t *testing.T) {
+	installMockOpen(t)
+
+	// Construct with the package-level default so fresh pools would
+	// otherwise reset to it; then override per-instance and verify the
+	// override survives Reconnect.
+	db, err := NewFromDSN(testDSN, testDSN)
+	require.NoError(t, err)
+
+	const override = 3 * time.Second
+	db.SetMaxConnectionTime(override)
+
+	require.NoError(t, db.Reconnect())
+	require.Equal(t, override, db.MaxConnectionTime, "Reconnect must not clobber the field")
+	// The fresh pool had SetConnMaxLifetime re-applied; we can't observe
+	// the pool's internal lifetime, but covering the branch that does
+	// the re-application is what this test is here for (the exec above
+	// walks the Reconnect code that touches both branches).
+}
+
+func TestReconnect_PreservesMaxConnectionTimeOverride_DualPool(t *testing.T) {
+	installMockOpen(t)
+
+	db, err := NewFromDSNDualPool(testDSN)
+	require.NoError(t, err)
+
+	const override = 9 * time.Second
+	db.SetMaxConnectionTime(override)
+
+	require.NoError(t, db.Reconnect())
+	require.Equal(t, override, db.MaxConnectionTime)
+	// fresh.Reads != fresh.Writes on the dual-pool path, so this also
+	// exercises the branch that applies the lifetime to a distinct
+	// reads pool.
+	require.NotSame(t, writesPool(t, db), db.Reads)
+}
+
+func TestExec_RespectsDBMaxExecutionTime(t *testing.T) {
+	// Using an unrealistically small budget so backoff.Retry stops
+	// after a single retryable error instead of waiting the
+	// package-level default.
+	h := &failingExecHandler{
+		errors: []error{
+			errMockRetry, errMockRetry, errMockRetry, errMockRetry,
+			errMockRetry, errMockRetry, errMockRetry, errMockRetry,
+		},
+	}
+
+	db := &Database{MaxExecutionTime: time.Nanosecond}
+
+	start := time.Now()
+	_, err := db.exec(h, context.Background(), nil, true, "SELECT 1")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errMockRetry), "err = %v", err)
+	require.Less(t, elapsed, time.Second, "budget not honored, elapsed=%s", elapsed)
+	require.Less(t, h.calls, len(h.errors), "should not exhaust all retries with 1ns budget")
+}
+
+func TestSelect_RespectsDBMaxExecutionTime(t *testing.T) {
+	// getTestDatabase gives us a *Database whose Reads/Writes are a real
+	// sqlmock *sql.DB. Override MaxExecutionTime and force a retryable
+	// error via sqlmock to exercise select.go's budget.
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	db.MaxExecutionTime = time.Nanosecond
+	mock.ExpectQuery(`^SELECT 1$`).WillReturnError(errMockRetry)
+
+	start := time.Now()
+	var out []int
+	err := db.Select(&out, "SELECT 1", 0)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errMockRetry), "err = %v", err)
+	require.Less(t, elapsed, time.Second, "budget not honored, elapsed=%s", elapsed)
+}
+
+func TestExists_RespectsDBMaxExecutionTime(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	db.MaxExecutionTime = time.Nanosecond
+	mock.ExpectQuery(`^SELECT 1$`).WillReturnError(errMockRetry)
+
+	start := time.Now()
+	_, err := db.Exists("SELECT 1", 0)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errMockRetry), "err = %v", err)
+	require.Less(t, elapsed, time.Second, "budget not honored, elapsed=%s", elapsed)
+}

--- a/exists.go
+++ b/exists.go
@@ -133,7 +133,7 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 
 	options := []backoff.RetryOption{
 		backoff.WithBackOff(b),
-		backoff.WithMaxElapsedTime(MaxExecutionTime),
+		backoff.WithMaxElapsedTime(db.MaxExecutionTime),
 	}
 	if MaxAttempts > 0 {
 		options = append(options, backoff.WithMaxTries(uint(MaxAttempts)))

--- a/pool_test.go
+++ b/pool_test.go
@@ -158,7 +158,7 @@ func TestOpenPool_PingFailureClosesPool(t *testing.T) {
 		return pool, nil
 	}
 
-	_, err := openPool(testDSN, "writes")
+	_, err := openPool(testDSN, "writes", 0)
 	require.ErrorIs(t, err, pingErr)
 	// ExpectClose on the mock asserts openPool closed the pool on error.
 	require.NoError(t, capturedMock.ExpectationsWereMet())

--- a/select.go
+++ b/select.go
@@ -235,7 +235,7 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 
 	options := []backoff.RetryOption{
 		backoff.WithBackOff(b),
-		backoff.WithMaxElapsedTime(MaxExecutionTime),
+		backoff.WithMaxElapsedTime(db.MaxExecutionTime),
 	}
 	if MaxAttempts > 0 {
 		options = append(options, backoff.WithMaxTries(uint(MaxAttempts)))


### PR DESCRIPTION
## Summary
- Closes #144
- `*Database` now owns `MaxExecutionTime` and `MaxConnectionTime` fields, seeded from the package-level vars at construction, so long-running processes can override the 27s Lambda-oriented default per-instance without affecting other imports.
- `exec`/`select`/`exists` read `db.MaxExecutionTime` for `backoff.WithMaxElapsedTime`.
- New `SetMaxConnectionTime(d)` setter updates the field and re-applies `SetConnMaxLifetime` to both pools.
- `Reconnect` preserves any per-instance `MaxConnectionTime` override (it would otherwise silently revert to the package default since the fresh `*Database` is built through `NewFromDSN` / `NewFromDSNDualPool`).
- All five constructors (`NewFromDSN`, `NewFromDSNDualPool`, `NewFromConn`, `NewLocalWriter`, `NewWriter`) seed both fields.
- Env var table in `CLAUDE.md` updated.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New `execution_time_test.go` covers every changed line:
  - Field seeding on all five constructors
  - `SetMaxConnectionTime` across `*sql.DB`/non-DB Writes and nil Reads
  - `Reconnect` override preservation on both shared and dual pool paths
  - Backoff budget honoured by `exec`/`select`/`exists` via `db.MaxExecutionTime`
- [x] Two rounds of codex review, clean on second pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)