### PR TITLE
Reacquire fresh conn on ErrInvalidConn in select retry (#150)

### DIFF
--- a/select.go
+++ b/select.go
@@ -190,17 +190,11 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 	if c, ok := conn.(*sql.DB); ok {
 		if c == db.Reads {
 			getFreshConn = func(ctx context.Context) (*sql.Conn, error) {
-				if db.Reads == nil {
-					return nil, fmt.Errorf("reads pool is nil")
-				}
 				return db.Reads.Conn(ctx)
 			}
 		} else if w, ok := db.Writes.(*sql.DB); ok && w == c {
 			getFreshConn = func(ctx context.Context) (*sql.Conn, error) {
 				w, _ := db.Writes.(*sql.DB)
-				if w == nil {
-					return nil, fmt.Errorf("writes pool is not a *sql.DB")
-				}
 				return w.Conn(ctx)
 			}
 		} else {
@@ -262,21 +256,24 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 				}
 				// Swap the dead dedicated conn for a fresh one from the
 				// current pool so the retry doesn't hit the same dead
-				// conn and burn the whole retry budget.
-				if getFreshConn != nil {
-					if currentConn != nil {
-						if closeErr := currentConn.Close(); closeErr != nil {
-							db.Logger.Warn("failed to close stale connection", "err", closeErr)
-						}
-						currentConn = nil
-					}
-					fresh, acqErr := getFreshConn(ctx)
-					if acqErr != nil {
-						return nil, acqErr
-					}
-					currentConn = fresh
-					conn = fresh
+				// conn and burn the whole retry budget. If conn wasn't a
+				// *sql.DB (e.g. inside a *sql.Tx), we can't reacquire
+				// the tx is bound to the dead conn, so fail fast.
+				if getFreshConn == nil {
+					return nil, backoff.Permanent(err)
 				}
+				if currentConn != nil {
+					if closeErr := currentConn.Close(); closeErr != nil {
+						db.Logger.Warn("failed to close stale connection", "err", closeErr)
+					}
+					currentConn = nil
+				}
+				fresh, acqErr := getFreshConn(ctx)
+				if acqErr != nil {
+					return nil, acqErr
+				}
+				currentConn = fresh
+				conn = fresh
 				return nil, err
 			}
 			return nil, backoff.Permanent(err)

--- a/select.go
+++ b/select.go
@@ -181,20 +181,49 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 		}
 	}
 
+	var currentConn *sql.Conn
+	// getFreshConn reacquires a dedicated conn from the pool originally
+	// passed in. It reads db.Reads / db.Writes live so it picks up the
+	// replacement pool after Reconnect.
+	var getFreshConn func(ctx context.Context) (*sql.Conn, error)
+
 	if c, ok := conn.(*sql.DB); ok {
-		c2, err := c.Conn(ctx)
-		if c2 != nil {
-			defer func() {
-				if err := c2.Close(); err != nil {
-					db.Logger.Warn("failed to close connection", "err", err)
+		if c == db.Reads {
+			getFreshConn = func(ctx context.Context) (*sql.Conn, error) {
+				if db.Reads == nil {
+					return nil, fmt.Errorf("reads pool is nil")
 				}
-			}()
+				return db.Reads.Conn(ctx)
+			}
+		} else if w, ok := db.Writes.(*sql.DB); ok && w == c {
+			getFreshConn = func(ctx context.Context) (*sql.Conn, error) {
+				w, _ := db.Writes.(*sql.DB)
+				if w == nil {
+					return nil, fmt.Errorf("writes pool is not a *sql.DB")
+				}
+				return w.Conn(ctx)
+			}
+		} else {
+			getFreshConn = func(ctx context.Context) (*sql.Conn, error) {
+				return c.Conn(ctx)
+			}
 		}
+
+		c2, err := getFreshConn(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get connection: %w", err)
 		}
+		currentConn = c2
 		conn = c2
 	}
+
+	defer func() {
+		if currentConn != nil {
+			if err := currentConn.Close(); err != nil {
+				db.Logger.Warn("failed to close connection", "err", err)
+			}
+		}
+	}()
 
 	start := time.Now()
 
@@ -225,7 +254,30 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 				return nil, err
 			}
 			if errors.Is(err, mysql.ErrInvalidConn) {
-				return nil, db.Test()
+				// Reconnect if the pool itself is down. Test is a no-op
+				// when the pool is healthy and only this dedicated conn
+				// died.
+				if testErr := db.Test(); testErr != nil {
+					return nil, testErr
+				}
+				// Swap the dead dedicated conn for a fresh one from the
+				// current pool so the retry doesn't hit the same dead
+				// conn and burn the whole retry budget.
+				if getFreshConn != nil {
+					if currentConn != nil {
+						if closeErr := currentConn.Close(); closeErr != nil {
+							db.Logger.Warn("failed to close stale connection", "err", closeErr)
+						}
+						currentConn = nil
+					}
+					fresh, acqErr := getFreshConn(ctx)
+					if acqErr != nil {
+						return nil, acqErr
+					}
+					currentConn = fresh
+					conn = fresh
+				}
+				return nil, err
 			}
 			return nil, backoff.Permanent(err)
 		}

--- a/select_test.go
+++ b/select_test.go
@@ -10,6 +10,7 @@ import (
 
 	"cloud.google.com/go/civil"
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
@@ -661,4 +662,37 @@ func TestSelectNoInsertFieldMapping(t *testing.T) {
 	require.Equal(t, 1, dest[0].ID)
 	require.Equal(t, "item-value", dest[0].CustomLineItem)  // LineItem column -> CustomLineItem field
 	require.Equal(t, "model-value", dest[0].LineItemModel) // LineItemModel column -> LineItemModel field
+}
+
+// TestSelectReacquiresConnOnErrInvalidConn verifies that when QueryContext
+// returns mysql.ErrInvalidConn on a dedicated conn checked out from the
+// pool, select.go releases the dead conn and grabs a fresh one before
+// retrying. Without that swap the retry would hit the same dead conn and
+// burn the entire retry budget.
+func TestSelectReacquiresConnOnErrInvalidConn(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectQuery("^SELECT 1$").WillReturnError(mysql.ErrInvalidConn)
+	mock.ExpectQuery("^SELECT 1$").
+		WillReturnRows(sqlmock.NewRows([]string{"col"}).AddRow(int64(1)))
+
+	var v int64
+	require.NoError(t, db.Select(&v, "SELECT 1", 0))
+	require.Equal(t, int64(1), v)
+}
+
+// TestSelectWritesReacquiresConnOnErrInvalidConn covers the SelectWrites
+// path, which passes db.Writes.(*sql.DB) through the same retry logic.
+func TestSelectWritesReacquiresConnOnErrInvalidConn(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectQuery("^SELECT 2$").WillReturnError(mysql.ErrInvalidConn)
+	mock.ExpectQuery("^SELECT 2$").
+		WillReturnRows(sqlmock.NewRows([]string{"col"}).AddRow(int64(2)))
+
+	var v int64
+	require.NoError(t, db.SelectWrites(&v, "SELECT 2", 0))
+	require.Equal(t, int64(2), v)
 }

--- a/select_test.go
+++ b/select_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"reflect"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -682,17 +683,160 @@ func TestSelectReacquiresConnOnErrInvalidConn(t *testing.T) {
 	require.Equal(t, int64(1), v)
 }
 
-// TestSelectWritesReacquiresConnOnErrInvalidConn covers the SelectWrites
-// path, which passes db.Writes.(*sql.DB) through the same retry logic.
+// getDualPoolTestDatabase builds a Database whose Reads and Writes point
+// at independent sqlmock pools so tests can exercise the writes-specific
+// branch of the conn-reacquire logic (c == db.Writes.(*sql.DB)).
+func getDualPoolTestDatabase(t *testing.T) (*Database, sqlmock.Sqlmock, sqlmock.Sqlmock, func()) {
+	writesDB, writesMock, err := sqlmock.New()
+	require.NoError(t, err)
+	readsDB, readsMock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	writesMock.ExpectQuery("^SELECT @@max_allowed_packet$").
+		WillReturnRows(sqlmock.NewRows([]string{"@@max_allowed_packet"}).
+			AddRow(int64(4194304)))
+
+	db, err := NewFromConn(writesDB, readsDB)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		require.NoError(t, writesMock.ExpectationsWereMet())
+		require.NoError(t, readsMock.ExpectationsWereMet())
+		if err := writesDB.Close(); err != nil {
+			t.Logf("failed to close writes mock: %v", err)
+		}
+		if err := readsDB.Close(); err != nil {
+			t.Logf("failed to close reads mock: %v", err)
+		}
+	}
+	return db, writesMock, readsMock, cleanup
+}
+
+// TestSelectWritesReacquiresConnOnErrInvalidConn covers the writes branch
+// of getFreshConn — c matches db.Writes.(*sql.DB) but not db.Reads.
 func TestSelectWritesReacquiresConnOnErrInvalidConn(t *testing.T) {
-	db, mock, cleanup := getTestDatabase(t)
+	db, writesMock, _, cleanup := getDualPoolTestDatabase(t)
 	defer cleanup()
 
-	mock.ExpectQuery("^SELECT 2$").WillReturnError(mysql.ErrInvalidConn)
-	mock.ExpectQuery("^SELECT 2$").
+	writesMock.ExpectQuery("^SELECT 2$").WillReturnError(mysql.ErrInvalidConn)
+	writesMock.ExpectQuery("^SELECT 2$").
 		WillReturnRows(sqlmock.NewRows([]string{"col"}).AddRow(int64(2)))
 
 	var v int64
 	require.NoError(t, db.SelectWrites(&v, "SELECT 2", 0))
 	require.Equal(t, int64(2), v)
+}
+
+// TestSelectUnrelatedPoolReacquiresOnErrInvalidConn covers the fallback
+// branch where the passed conn is a *sql.DB that matches neither db.Reads
+// nor db.Writes — getFreshConn keeps using that pool directly.
+func TestSelectUnrelatedPoolReacquiresOnErrInvalidConn(t *testing.T) {
+	db, _, _, cleanup := getDualPoolTestDatabase(t)
+	defer cleanup()
+
+	thirdDB, thirdMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, thirdMock.ExpectationsWereMet())
+		if err := thirdDB.Close(); err != nil {
+			t.Logf("failed to close third mock: %v", err)
+		}
+	}()
+
+	thirdMock.ExpectQuery("^SELECT 3$").WillReturnError(mysql.ErrInvalidConn)
+	thirdMock.ExpectQuery("^SELECT 3$").
+		WillReturnRows(sqlmock.NewRows([]string{"col"}).AddRow(int64(3)))
+
+	var v int64
+	require.NoError(t, db.query(thirdDB, context.Background(), &v, "SELECT 3", 0))
+	require.Equal(t, int64(3), v)
+}
+
+// errInvalidConnCounter counts QueryContext calls and always returns
+// mysql.ErrInvalidConn — stands in for a *sql.Tx whose conn has died.
+type errInvalidConnCounter struct {
+	calls int
+}
+
+func (h *errInvalidConnCounter) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	panic("unexpected ExecContext call in errInvalidConnCounter")
+}
+
+func (h *errInvalidConnCounter) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	h.calls++
+	return nil, mysql.ErrInvalidConn
+}
+
+// TestSelectErrInvalidConnFailsFastWithoutFreshConn verifies that when
+// conn is not a *sql.DB (e.g. a *sql.Tx), an ErrInvalidConn is treated as
+// permanent. Without that fail-fast the backoff loop would spin on the
+// same dead conn until the whole retry budget was burned.
+func TestSelectErrInvalidConnFailsFastWithoutFreshConn(t *testing.T) {
+	h := &errInvalidConnCounter{}
+	db := &Database{Logger: DefaultLogger(), testMx: new(sync.Mutex)}
+
+	var out []int
+	err := db.query(h, context.Background(), &out, "SELECT 1", 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, mysql.ErrInvalidConn)
+	require.Equal(t, 1, h.calls, "expected exactly one attempt, got %d", h.calls)
+}
+
+// TestSelectPropagatesTestError verifies that when db.Test() fails during
+// the ErrInvalidConn recovery path (pool Ping fails and Reconnect also
+// fails), that error surfaces to the caller instead of being swallowed.
+func TestSelectPropagatesTestError(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 1
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	mockDB, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	require.NoError(t, err)
+	defer func() {
+		if err := mockDB.Close(); err != nil {
+			t.Logf("failed to close mock: %v", err)
+		}
+	}()
+
+	mock.ExpectQuery("^SELECT @@max_allowed_packet$").
+		WillReturnRows(sqlmock.NewRows([]string{"@@max_allowed_packet"}).
+			AddRow(int64(4194304)))
+
+	db, err := NewFromConn(mockDB, mockDB)
+	require.NoError(t, err)
+
+	// First QueryContext fails with ErrInvalidConn — drives us into the
+	// Test() recovery branch. MonitorPingsOption+no ExpectPing makes the
+	// subsequent db.Test() Ping fail, and since WritesDSN/ReadsDSN are
+	// empty strings (NewFromConn doesn't know them), Reconnect also
+	// fails — so Test() returns an error.
+	mock.ExpectQuery("^SELECT 9$").WillReturnError(mysql.ErrInvalidConn)
+
+	var v int64
+	err = db.Select(&v, "SELECT 9", 0)
+	require.Error(t, err)
+}
+
+// TestSelectFailsWhenInitialConnAcquireFails verifies the initial
+// getFreshConn failure path — if the pool is closed before the query, we
+// surface the acquire error instead of entering the retry loop.
+func TestSelectFailsWhenInitialConnAcquireFails(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	mock.ExpectQuery("^SELECT @@max_allowed_packet$").
+		WillReturnRows(sqlmock.NewRows([]string{"@@max_allowed_packet"}).
+			AddRow(int64(4194304)))
+
+	db, err := NewFromConn(mockDB, mockDB)
+	require.NoError(t, err)
+
+	// sqlmock complains about unexpected Close, but we intentionally
+	// close here to force the pool into a state where Conn(ctx) fails.
+	_ = mockDB.Close()
+
+	var v int64
+	err = db.Select(&v, "SELECT 1", 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to get connection")
 }


### PR DESCRIPTION
## Summary
- Fixes #150. The dedicated `*sql.Conn` checked out at the top of `query()` was held across the retry loop, so an `ErrInvalidConn` would keep hitting the same dead conn until `MaxExecutionTime` expired (~27s default).
- On `ErrInvalidConn` we now `db.Test()` first (reconnects the pool if down), then close the dead dedicated conn and reacquire a fresh one from the current pool before backoff retries. The `getFreshConn` closure reads `db.Reads` / `db.Writes` live so it picks up the replacement pool after `Reconnect`.
- Also returns the original error as non-permanent so backoff actually retries — the prior `return nil, db.Test()` would return `(nil, nil)` on a healthy pool and trip the downstream "nil rows without error" path instead of retrying.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=3m`
- [x] New `TestSelectReacquiresConnOnErrInvalidConn` covers `Select` (reads pool)
- [x] New `TestSelectWritesReacquiresConnOnErrInvalidConn` covers `SelectWrites` (writes pool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)