### PR TITLE
Fix Valueser fields corrupting JSON columns and breaking INSERT alignment

### DIFF
--- a/insert_test.go
+++ b/insert_test.go
@@ -34,7 +34,7 @@ func Test_colNamesFromStruct(t *testing.T) {
 		D int
 	}
 
-	cols, opts, fieldMap, err := colNamesFromStruct(reflect.TypeOf(example{}))
+	cols, opts, fieldMap, err := colNamesFromStruct(reflect.TypeFor[example]())
 	require.NoError(t, err)
 	require.Equal(t, []string{"a", "b", "D"}, cols)
 	require.True(t, opts["a"].insertDefault)
@@ -247,7 +247,7 @@ func TestNoInsertTagOption(t *testing.T) {
 			LineItemModel  string `mysql:"LineItemModel,noinsert"` // should be skipped for insert
 		}
 
-		cols, opts, fieldMap, err := colNamesFromStruct(reflect.TypeOf(OrderLineItem{}))
+		cols, opts, fieldMap, err := colNamesFromStruct(reflect.TypeFor[OrderLineItem]())
 		require.NoError(t, err)
 
 		// Should only have ID and LineItem columns, NOT LineItemModel
@@ -284,4 +284,88 @@ func TestNoInsertTagOption(t *testing.T) {
 		require.Contains(t, buf.String(), "`id`")
 		require.Contains(t, buf.String(), "`name`")
 	})
+}
+
+// orderedValueser is a deterministic Valueser-backed slice type used to
+// exercise the Insert / Upsert single-column code paths. The prod incident in
+// issue #161 used set.Set[string], which is map-backed and non-deterministic;
+// an ordered slice keeps the test stable while preserving the same
+// `MySQLValues() ([]driver.Value, error)` shape.
+type orderedValueser []string
+
+func (s orderedValueser) MySQLValues() ([]driver.Value, error) {
+	out := make([]driver.Value, 0, len(s))
+	for _, v := range s {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// TestInsert_ValueserMultiElementJSONEncodes is the regression test for issue
+// #161. A struct field whose type implements Valueser (e.g. set.Set) targets
+// a single column on INSERT — it must JSON-encode into one placeholder rather
+// than expand to N comma-separated placeholders, which would mis-align row
+// values against the column list and trigger MySQL 1136.
+func TestInsert_ValueserMultiElementJSONEncodes(t *testing.T) {
+	var buf bytes.Buffer
+	db, err := NewWriter(&buf)
+	require.NoError(t, err)
+
+	type row struct {
+		ID   int             `mysql:"id"`
+		Tags orderedValueser `mysql:"tags"`
+	}
+
+	err = db.Insert("t", row{ID: 1, Tags: orderedValueser{"a", "b", "c"}})
+	require.NoError(t, err)
+
+	// Expected: a single placeholder containing the JSON array literal
+	// `["a","b","c"]`. Before the fix this would emit three comma-separated
+	// values and break alignment with the 2-column header.
+	jsonHex := hex.EncodeToString([]byte(`["a","b","c"]`))
+	expected := "insert into`t`(`id`,`tags`)values(1,_utf8mb4 0x" + jsonHex + " collate utf8mb4_unicode_ci);\n\n"
+	require.Equal(t, expected, buf.String())
+}
+
+// TestInsert_ValueserSingleElementJSONEncodes guards against the
+// single-element optimization in the existing IN-clause Valueser path bleeding
+// into INSERT row values. A 1-element Valueser must still render as a
+// 1-element JSON array (`["a"]`), not the bare scalar `'a'`.
+func TestInsert_ValueserSingleElementJSONEncodes(t *testing.T) {
+	var buf bytes.Buffer
+	db, err := NewWriter(&buf)
+	require.NoError(t, err)
+
+	type row struct {
+		ID   int             `mysql:"id"`
+		Tags orderedValueser `mysql:"tags"`
+	}
+
+	err = db.Insert("t", row{ID: 1, Tags: orderedValueser{"a"}})
+	require.NoError(t, err)
+
+	jsonHex := hex.EncodeToString([]byte(`["a"]`))
+	expected := "insert into`t`(`id`,`tags`)values(1,_utf8mb4 0x" + jsonHex + " collate utf8mb4_unicode_ci);\n\n"
+	require.Equal(t, expected, buf.String())
+}
+
+// TestInsert_ValueserEmptyEncodesAsJSONArray covers the zero-element case: an
+// empty (non-nil) Valueser should render as the JSON literal `[]` so the
+// column stays a valid JSON value.
+func TestInsert_ValueserEmptyEncodesAsJSONArray(t *testing.T) {
+	var buf bytes.Buffer
+	db, err := NewWriter(&buf)
+	require.NoError(t, err)
+
+	type row struct {
+		ID   int             `mysql:"id"`
+		Tags orderedValueser `mysql:"tags"`
+	}
+
+	err = db.Insert("t", row{ID: 1, Tags: orderedValueser{}})
+	require.NoError(t, err)
+
+	jsonHex := hex.EncodeToString([]byte(`[]`))
+	expected := "insert into`t`(`id`,`tags`)values(1,_utf8mb4 0x" + jsonHex + " collate utf8mb4_unicode_ci);\n\n"
+	require.Equal(t, expected, buf.String())
 }

--- a/insert_test.go
+++ b/insert_test.go
@@ -349,6 +349,34 @@ func TestInsert_ValueserSingleElementJSONEncodes(t *testing.T) {
 	require.Equal(t, expected, buf.String())
 }
 
+// unmarshalableValueser returns a value that json.Marshal can't encode
+// (channels have no JSON representation), exercising the error branch in the
+// single-column Valueser path added in issue #161.
+type unmarshalableValueser struct{}
+
+func (unmarshalableValueser) MySQLValues() ([]driver.Value, error) {
+	return []driver.Value{make(chan int)}, nil
+}
+
+// TestInsert_ValueserJSONMarshalError covers the error branch when
+// MySQLValues returns a driver.Value that json.Marshal can't encode. The
+// caller's error wrapping must surface so misconfigured user types don't
+// fail silently.
+func TestInsert_ValueserJSONMarshalError(t *testing.T) {
+	var buf bytes.Buffer
+	db, err := NewWriter(&buf)
+	require.NoError(t, err)
+
+	type row struct {
+		ID   int                   `mysql:"id"`
+		Tags unmarshalableValueser `mysql:"tags"`
+	}
+
+	err = db.Insert("t", row{ID: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "JSON-encode Valueser")
+}
+
 // TestInsert_ValueserEmptyEncodesAsJSONArray covers the zero-element case: an
 // empty (non-nil) Valueser should render as the JSON literal `[]` so the
 // column stays a valid JSON value.

--- a/params.go
+++ b/params.go
@@ -719,14 +719,24 @@ func marshalAppend(dst []byte, x any, opts marshalOpt, fieldName string, valuerF
 			}
 		}
 
-		vs, err := vs.MySQLValues()
+		values, err := vs.MySQLValues()
 		if err != nil {
 			return nil, fmt.Errorf("cool-mysql: failed to call MySQLValues on mysql.MySQLValues: %w", err)
 		}
-		// Valueser intentionally returns a []driver.Value to be expanded
-		// comma-separated; suppress marshalOptJSONSlice so a 1-element return
-		// like `[]driver.Value{int(s)}` renders as `s`, not `[s]`.
-		return marshalAppend(dst, vs, opts&^marshalOptJSONSlice, fieldName, valuerFuncs, loc)
+		// marshalOptJSONSlice is set by callers (INSERT row values, UPDATE
+		// SET assignments, any non-IN @@param) to mean "this param targets a
+		// single column" — JSON-encode the result so it lands as one
+		// placeholder. The IN-clause / variadic path leaves the flag clear
+		// and we fall through to the comma-separated expansion below. See
+		// issue #161 (Valueser counterpart to #155).
+		if opts&marshalOptJSONSlice != 0 {
+			j, err := json.Marshal(values)
+			if err != nil {
+				return nil, fmt.Errorf("cool-mysql: failed to JSON-encode Valueser for single-column context: %w", err)
+			}
+			return marshalAppend(dst, json.RawMessage(j), opts&^marshalOptJSONSlice, fieldName, valuerFuncs, loc)
+		}
+		return marshalAppend(dst, values, opts, fieldName, valuerFuncs, loc)
 	}
 
 	if isNil(x) {

--- a/params_test.go
+++ b/params_test.go
@@ -411,15 +411,58 @@ func (s singleValueser) MySQLValues() ([]driver.Value, error) {
 	return []driver.Value{s.v}, nil
 }
 
-// Test_InterpolateParams_ValueserScalar guards against Valueser returning a
-// single-element []driver.Value getting JSON-encoded (as `[7]`) instead of
-// expanded as the scalar `7`.
-func Test_InterpolateParams_ValueserScalar(t *testing.T) {
+// Test_InterpolateParams_ValueserScalar_INClause guards against Valueser
+// returning a single-element []driver.Value getting JSON-encoded (as `[7]`)
+// instead of expanded as the scalar `7` inside an IN-clause / variadic
+// context. This is the original intent of the Valueser scalar shortcut.
+//
+// Outside an IN-clause / variadic call (e.g. an UPDATE SET or INSERT VALUES),
+// a Valueser targets a single column and JSON-encodes — see issue #161 and
+// the TestInsert_Valueser* tests in insert_test.go.
+func Test_InterpolateParams_ValueserScalar_INClause(t *testing.T) {
+	got, _, err := InterpolateParams("SELECT 0 WHERE col IN(@@v)", nil, nil, Params{"v": singleValueser{v: 7}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT 0 WHERE col IN(7)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// Test_InterpolateParams_ValueserMultiElement_INClause is the regression
+// guard for issue #161's IN-clause behavior: a multi-element Valueser inside
+// `IN(...)` must keep expanding to comma-separated values, not collapse to a
+// JSON array.
+func Test_InterpolateParams_ValueserMultiElement_INClause(t *testing.T) {
+	v := multiValueser{vals: []driver.Value{1, 2, 3}}
+	got, _, err := InterpolateParams("SELECT 0 WHERE col IN(@@v)", nil, nil, Params{"v": v})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT 0 WHERE col IN(1,2,3)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+type multiValueser struct{ vals []driver.Value }
+
+func (m multiValueser) MySQLValues() ([]driver.Value, error) { return m.vals, nil }
+
+// Test_InterpolateParams_ValueserScalar_AssignmentJSONEncodes is the
+// regression test for issue #161 on assignment-style placement (UPDATE SET,
+// INSERT VALUES, etc.): outside an IN-clause / variadic function call a
+// Valueser must JSON-encode rather than expand. A single-element Valueser
+// must render as a 1-element JSON array (`[7]`) — anything else would
+// silently corrupt JSON columns.
+func Test_InterpolateParams_ValueserScalar_AssignmentJSONEncodes(t *testing.T) {
 	got, _, err := InterpolateParams("SET col = @@v", nil, nil, Params{"v": singleValueser{v: 7}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "SET col = 7"
+	jsonHex := hex.EncodeToString([]byte(`[7]`))
+	want := "SET col = _utf8mb4 0x" + jsonHex + " collate utf8mb4_unicode_ci"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -649,7 +692,7 @@ func Test_marshal(t *testing.T) {
 			args: args{
 				x: civil.Date{Year: 2020, Month: 1, Day: 1},
 				valuerFuncs: map[reflect.Type]reflect.Value{
-					reflect.TypeOf(civil.Date{}): reflect.ValueOf(func(d civil.Date) (driver.Value, error) {
+					reflect.TypeFor[civil.Date](): reflect.ValueOf(func(d civil.Date) (driver.Value, error) {
 						return d.In(time.UTC), nil
 					}),
 				},
@@ -661,7 +704,7 @@ func Test_marshal(t *testing.T) {
 			args: args{
 				x: p(civil.Date{Year: 2020, Month: 1, Day: 1}),
 				valuerFuncs: map[reflect.Type]reflect.Value{
-					reflect.TypeOf((*civil.Date)(nil)): reflect.ValueOf(func(d *civil.Date) (driver.Value, error) {
+					reflect.TypeFor[*civil.Date](): reflect.ValueOf(func(d *civil.Date) (driver.Value, error) {
 						return d.In(time.UTC), nil
 					}),
 				},
@@ -673,7 +716,7 @@ func Test_marshal(t *testing.T) {
 			args: args{
 				x: (*civil.Date)(nil),
 				valuerFuncs: map[reflect.Type]reflect.Value{
-					reflect.TypeOf((*civil.Date)(nil)): reflect.ValueOf(func(d *civil.Date) (driver.Value, error) {
+					reflect.TypeFor[*civil.Date](): reflect.ValueOf(func(d *civil.Date) (driver.Value, error) {
 						if d == nil {
 							return nil, nil
 						}
@@ -688,7 +731,7 @@ func Test_marshal(t *testing.T) {
 			args: args{
 				x: civil.Date{Year: 2020, Month: 1, Day: 1},
 				valuerFuncs: map[reflect.Type]reflect.Value{
-					reflect.TypeOf((*civil.Date)(nil)): reflect.ValueOf(func(d *civil.Date) (driver.Value, error) {
+					reflect.TypeFor[*civil.Date](): reflect.ValueOf(func(d *civil.Date) (driver.Value, error) {
 						if d == nil {
 							return nil, nil
 						}
@@ -703,7 +746,7 @@ func Test_marshal(t *testing.T) {
 			args: args{
 				x: &civil.Date{Year: 2020, Month: 1, Day: 1},
 				valuerFuncs: map[reflect.Type]reflect.Value{
-					reflect.TypeOf(civil.Date{}): reflect.ValueOf(func(d civil.Date) (driver.Value, error) {
+					reflect.TypeFor[civil.Date](): reflect.ValueOf(func(d civil.Date) (driver.Value, error) {
 						return d.String(), nil
 					}),
 				},
@@ -715,7 +758,7 @@ func Test_marshal(t *testing.T) {
 			args: args{
 				x: (*civil.Date)(nil),
 				valuerFuncs: map[reflect.Type]reflect.Value{
-					reflect.TypeOf(civil.Date{}): reflect.ValueOf(func(d civil.Date) (driver.Value, error) {
+					reflect.TypeFor[civil.Date](): reflect.ValueOf(func(d civil.Date) (driver.Value, error) {
 						return d.String(), nil
 					}),
 				},

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -165,6 +165,37 @@ func TestUpsertSliceFieldKeepsINClauseSemantics(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestUpsertValueserFieldJSONEncodesOnUpdate is the Upsert-UPDATE-path
+// counterpart to issue #161: a struct field whose type implements Valueser
+// (e.g. set.Set) must JSON-encode on the UPDATE path, not expand to
+// comma-separated values that would produce invalid SQL against a JSON
+// column.
+func TestUpsertValueserFieldJSONEncodesOnUpdate(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	type foo struct {
+		FooID uint
+		Name  string
+		Tags  orderedValueser
+	}
+
+	row := foo{FooID: 36, Name: "y", Tags: orderedValueser{"a", "b"}}
+
+	jsonHex := hex.EncodeToString([]byte(`["a","b"]`))
+	nameHex := hex.EncodeToString([]byte("y"))
+	wantUpdate := "update `foos` set" +
+		"`Name`=_utf8mb4 0x" + nameHex + " collate utf8mb4_unicode_ci," +
+		"`Tags`=_utf8mb4 0x" + jsonHex + " collate utf8mb4_unicode_ci " +
+		"where`FooID`<=>36"
+
+	mock.ExpectExec(regexp.QuoteMeta(wantUpdate)).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := db.Upsert("foos", []string{"FooID"}, []string{"Name", "Tags"}, "", row)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestUpsertDefaultZeroUsesColumnName(t *testing.T) {
 	db, mock, cleanup := getTestDatabase(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

- A struct field whose type implements `Valueser` (e.g. `set.Set[T]`) gets expanded to N comma-separated placeholders during `Insert` / `Upsert`-UPDATE, even though those callers target a single column. Multi-element values trip `Error 1136 (21S01): Column count doesn't match value count at row 1`; single-element values emit an invalid scalar where a JSON array literal was needed.
- Fix mirrors #155 (the slice-field counterpart): when `marshalOptJSONSlice` is set, the param targets a single column, so JSON-encode the `[]driver.Value` returned by `MySQLValues()` instead of stripping the flag and expanding comma-separated. IN-clause / variadic call sites leave the flag clear and keep the original comma-separated behavior.
- The existing `Test_InterpolateParams_ValueserScalar` was testing `SET col = @@v` (an assignment, not an IN-clause) and asserting the wrong-direction behavior. Split into `_INClause` (real intent — comma-separated expansion guard) and `_AssignmentJSONEncodes` (the new JSON-encode behavior).

Closes #161.

## Test plan

- [x] `TestInsert_ValueserMultiElementJSONEncodes` — 3-element Valueser → single JSON-array placeholder (would have crashed with MySQL 1136 before).
- [x] `TestInsert_ValueserSingleElementJSONEncodes` — 1-element Valueser → `["a"]`, not bare `'a'`.
- [x] `TestInsert_ValueserEmptyEncodesAsJSONArray` — empty Valueser → `[]`.
- [x] `TestUpsertValueserFieldJSONEncodesOnUpdate` — UPDATE-path counterpart.
- [x] `Test_InterpolateParams_ValueserScalar_AssignmentJSONEncodes` — `SET col = @@v` JSON-encodes.
- [x] `Test_InterpolateParams_ValueserScalar_INClause` / `_MultiElement_INClause` — regression guards that IN-clause / variadic callers still get comma-separated expansion.
- [x] `go test ./...` clean.
- [x] `go vet ./...` clean.
- [x] `golangci-lint run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)