### PR TITLE
Retry mid-stream connection drops for buffered Select/Exists

### DIFF
--- a/exists.go
+++ b/exists.go
@@ -124,7 +124,20 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 				return false, err
 			}
 			if errors.Is(err, mysql.ErrInvalidConn) {
-				return false, db.Test()
+				// A *sql.Tx is bound to its (now dead) conn and can't be
+				// resumed on a fresh one, so fail fast. Otherwise reconnect
+				// if the pool is down and return the error so backoff
+				// re-runs — the next QueryContext draws a healthy pooled
+				// conn. Returning db.Test() directly would report (false,
+				// nil) as success when the pool is healthy, silently turning
+				// a dead conn into a "no rows" answer.
+				if tx != nil {
+					return false, backoff.Permanent(err)
+				}
+				if testErr := db.Test(); testErr != nil {
+					return false, testErr
+				}
+				return false, err
 			}
 			return false, backoff.Permanent(err)
 		}
@@ -140,6 +153,10 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 		}
 		if scanErr != nil {
 			if errors.Is(scanErr, mysql.ErrInvalidConn) || errors.Is(scanErr, driver.ErrBadConn) {
+				// A *sql.Tx can't be resumed on a fresh conn, so fail fast.
+				if tx != nil {
+					return false, backoff.Permanent(scanErr)
+				}
 				// Reconnect if the pool is down, then return the error so
 				// backoff re-runs the whole query (exists hasn't surfaced a
 				// result yet, so a re-run is always safe).

--- a/exists.go
+++ b/exists.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha3"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -106,7 +107,7 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 
 	b := backoff.NewExponentialBackOff()
 	var attempt int
-	operation := func() (*sql.Rows, error) {
+	operation := func() (bool, error) {
 		attempt++
 		rows, err := conn.QueryContext(ctx, replacedQuery)
 		tx, _ := conn.(*sql.Tx)
@@ -120,15 +121,37 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 		})
 		if err != nil {
 			if checkRetryError(err) {
-				return nil, err
+				return false, err
 			}
 			if errors.Is(err, mysql.ErrInvalidConn) {
-				return nil, db.Test()
+				return false, db.Test()
 			}
-			return nil, backoff.Permanent(err)
+			return false, backoff.Permanent(err)
 		}
 
-		return rows, nil
+		// The row-streaming phase (rows.Next / rows.Err) runs inside the
+		// retry so a connection that drops mid-stream is recoverable. exists
+		// reads a single boolean that the caller can't observe until we
+		// return, so re-running the whole query is always safe here.
+		got := rows.Next()
+		scanErr := rows.Err()
+		if closeErr := rows.Close(); closeErr != nil {
+			db.Logger.Warn("failed to close rows", "err", closeErr)
+		}
+		if scanErr != nil {
+			if errors.Is(scanErr, mysql.ErrInvalidConn) || errors.Is(scanErr, driver.ErrBadConn) {
+				// Reconnect if the pool is down, then return the error so
+				// backoff re-runs the whole query (exists hasn't surfaced a
+				// result yet, so a re-run is always safe).
+				if testErr := db.Test(); testErr != nil {
+					return false, testErr
+				}
+				return false, scanErr
+			}
+			return false, backoff.Permanent(scanErr)
+		}
+
+		return got, nil
 	}
 
 	options := []backoff.RetryOption{
@@ -139,21 +162,9 @@ func (db *Database) exists(conn handlerWithContext, ctx context.Context, query s
 		options = append(options, backoff.WithMaxTries(uint(MaxAttempts)))
 	}
 
-	rows, err := backoff.Retry(ctx, operation, options...)
+	exists, err = backoff.Retry(ctx, operation, options...)
 	if err != nil {
 		return exists, unwrapBackoffPermanent(err)
-	}
-	defer func() {
-		if rows != nil {
-			if err := rows.Close(); err != nil {
-				db.Logger.Warn("failed to close rows", "err", err)
-			}
-		}
-	}()
-
-	exists = rows.Next()
-	if err = rows.Err(); err != nil {
-		return exists, err
 	}
 
 	if len(cacheKey) != 0 {

--- a/select.go
+++ b/select.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha3"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -221,9 +222,161 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 
 	start := time.Now()
 
+	// swapConn handles a retriable connection-level error (ErrInvalidConn /
+	// ErrBadConn) by reconnecting the pool if it is down and swapping the
+	// dead dedicated conn for a fresh one, so the retry doesn't hit the same
+	// dead conn and burn the whole retry budget. It returns the error to hand
+	// back to backoff — either err (retry) or a backoff.Permanent wrapper
+	// (give up). It's used for both establishment failures and mid-stream
+	// connection drops during scanning.
+	swapConn := func(err error) error {
+		// Reconnect if the pool itself is down. Test is a no-op when the
+		// pool is healthy and only this dedicated conn died.
+		if testErr := db.Test(); testErr != nil {
+			return testErr
+		}
+		// If conn wasn't a *sql.DB (e.g. inside a *sql.Tx), we can't
+		// reacquire — the tx is bound to the dead conn, so fail fast.
+		if getFreshConn == nil {
+			return backoff.Permanent(err)
+		}
+		if currentConn != nil {
+			if closeErr := currentConn.Close(); closeErr != nil {
+				db.Logger.Warn("failed to close stale connection", "err", closeErr)
+			}
+			currentConn = nil
+		}
+		fresh, acqErr := getFreshConn(ctx)
+		if acqErr != nil {
+			return acqErr
+		}
+		currentConn = fresh
+		conn = fresh
+		return err
+	}
+
+	// retryable reports whether a connection that drops mid-stream (after rows
+	// have started flowing) can be recovered by discarding partial results and
+	// re-running the whole query. That's only safe for buffered dests — slice
+	// (*[]T) and single (*T) — because results accumulate into destRef.Elem()
+	// and aren't observed by the caller until query() returns. Channel and func
+	// dests emit each row via sendElement as it is scanned, so their rows are
+	// already out the door; they keep establishment-only retry.
+	retryable := destKind != reflect.Chan && destKind != reflect.Func
+
+	// resetAccumulator discards partially-collected results before a
+	// mid-stream retry so the re-run starts from a clean slate.
+	resetAccumulator := func() {
+		switch {
+		case multiRow && destKind == reflect.Slice:
+			destRef.Elem().Set(reflect.MakeSlice(destRef.Elem().Type(), 0, 0))
+		case !multiRow:
+			destRef.Elem().Set(reflect.Zero(destRef.Elem().Type()))
+		}
+		if cacheDuration > 0 {
+			cacheSlice = reflect.New(reflect.SliceOf(t)).Elem()
+		}
+	}
+
+	// scanRows runs the full row-streaming phase — column metadata, the scan
+	// loop, and rows.Err() — returning the number of rows observed. For
+	// buffered dests this runs inside the retry so a mid-stream connection
+	// drop is recoverable; for channel/func dests it still runs inside the
+	// operation but a mid-stream failure is treated as permanent (see below).
+	scanRows := func(rows *sql.Rows) (int, error) {
+		columns, err := rows.Columns()
+		if err != nil {
+			return 0, err
+		}
+
+		if t != mapRowType {
+			// since the map keys are literally the column names, we don't need to compare
+			// without case sensitivity. But for structs, we do.
+			for i := range columns {
+				columns[i] = strings.ToLower(columns[i])
+			}
+		}
+
+		ptrs, jsonFields, fieldsMap, ptrDests, isStruct, err := setupElementPtrs(db, t, indirectType, columns)
+		if err != nil {
+			return 0, err
+		}
+
+		i := 0
+		for rows.Next() {
+			el := reflect.New(t).Elem()
+			switch indirectType {
+			case mapRowType:
+				el.Set(reflect.MakeMapWithSize(mapRowType, len(columns)))
+			case sliceRowType:
+				el.Set(reflect.MakeSlice(reflect.SliceOf(t.Elem()), len(columns), len(columns)))
+			}
+
+			updateElementPtrs(el, &ptrs, jsonFields, columns, fieldsMap, ptrDests)
+
+			if err := rows.Scan(ptrs...); err != nil {
+				return i, err
+			}
+
+			for _, dest := range ptrDests {
+				if err := dest.assign(); err != nil {
+					return i, err
+				}
+			}
+
+			indirectEl := reflect.Indirect(el)
+
+			if indirectType == mapRowType {
+				// our map row is actually a map to pointers, not actual values, since
+				// you can't take the address of a value by map and key, so we need to fix that here
+				// to make usage intuitive
+
+				for _, k := range indirectEl.MapKeys() {
+					indirectEl.SetMapIndex(k, indirectEl.MapIndex(k).Elem().Elem())
+				}
+			}
+
+			for _, jsonField := range jsonFields {
+				if len(jsonField.j) == 0 {
+					continue
+				}
+
+				if !isStruct {
+					if err := json.Unmarshal(jsonField.j, el.Interface()); err != nil {
+						return i, fmt.Errorf("failed to unmarshal json into dest: %w", err)
+					}
+				} else {
+					f := indirectEl.FieldByIndex(jsonField.index)
+					if err := json.Unmarshal(jsonField.j, f.Addr().Interface()); err != nil {
+						return i, fmt.Errorf("failed to unmarshal json into struct field %q: %w", indirectEl.Type().FieldByIndex(jsonField.index).Name, err)
+					}
+				}
+			}
+
+			if len(cacheKey) != 0 {
+				cacheSlice = reflect.Append(cacheSlice, el)
+			}
+
+			i++
+
+			if err := sendElement(el); err != nil {
+				return i, err
+			}
+			if !multiRow {
+				break
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return i, err
+		}
+
+		return i, nil
+	}
+
 	b := backoff.NewExponentialBackOff()
 	var attempt int
-	operation := func() (*sql.Rows, error) {
+	var rowCount int
+	operation := func() (struct{}, error) {
 		attempt++
 		rows, err := conn.QueryContext(ctx, replacedQuery)
 
@@ -245,41 +398,33 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 			}
 
 			if checkRetryError(err) {
-				return nil, err
+				return struct{}{}, err
 			}
 			if errors.Is(err, mysql.ErrInvalidConn) {
-				// Reconnect if the pool itself is down. Test is a no-op
-				// when the pool is healthy and only this dedicated conn
-				// died.
-				if testErr := db.Test(); testErr != nil {
-					return nil, testErr
-				}
-				// Swap the dead dedicated conn for a fresh one from the
-				// current pool so the retry doesn't hit the same dead
-				// conn and burn the whole retry budget. If conn wasn't a
-				// *sql.DB (e.g. inside a *sql.Tx), we can't reacquire
-				// the tx is bound to the dead conn, so fail fast.
-				if getFreshConn == nil {
-					return nil, backoff.Permanent(err)
-				}
-				if currentConn != nil {
-					if closeErr := currentConn.Close(); closeErr != nil {
-						db.Logger.Warn("failed to close stale connection", "err", closeErr)
-					}
-					currentConn = nil
-				}
-				fresh, acqErr := getFreshConn(ctx)
-				if acqErr != nil {
-					return nil, acqErr
-				}
-				currentConn = fresh
-				conn = fresh
-				return nil, err
+				return struct{}{}, swapConn(err)
 			}
-			return nil, backoff.Permanent(err)
+			return struct{}{}, backoff.Permanent(err)
 		}
 
-		return rows, nil
+		n, scanErr := scanRows(rows)
+		if closeErr := rows.Close(); closeErr != nil {
+			db.Logger.Warn("failed to close rows", "err", closeErr)
+		}
+		if scanErr != nil {
+			// A connection that dies mid-stream surfaces as ErrInvalidConn /
+			// ErrBadConn from rows.Scan or rows.Err. For buffered dests the
+			// caller hasn't observed any rows yet, so discard the partial
+			// result and re-run the whole query on a fresh conn. Everything
+			// else — and every error on a channel/func dest — is permanent.
+			if retryable && (errors.Is(scanErr, mysql.ErrInvalidConn) || errors.Is(scanErr, driver.ErrBadConn)) {
+				resetAccumulator()
+				return struct{}{}, swapConn(scanErr)
+			}
+			return struct{}{}, backoff.Permanent(scanErr)
+		}
+
+		rowCount = n
+		return struct{}{}, nil
 	}
 
 	options := []backoff.RetryOption{
@@ -290,113 +435,11 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 		options = append(options, backoff.WithMaxTries(uint(MaxAttempts)))
 	}
 
-	rows, err := backoff.Retry(ctx, operation, options...)
-	if err != nil {
+	if _, err := backoff.Retry(ctx, operation, options...); err != nil {
 		return unwrapBackoffPermanent(err)
 	}
 
-	if rows == nil {
-		return fmt.Errorf("query returned nil rows without error")
-	}
-
-	defer func() {
-		if rows != nil {
-			if err := rows.Close(); err != nil {
-				db.Logger.Warn("failed to close rows", "err", err)
-			}
-		}
-	}()
-
-	columns, err := rows.Columns()
-	if err != nil {
-		return err
-	}
-
-	if t != mapRowType {
-		// since the map keys are literally the column names, we don't need to compare
-		// without case sensitivity. But for structs, we do.
-		for i := range columns {
-			columns[i] = strings.ToLower(columns[i])
-		}
-	}
-
-	ptrs, jsonFields, fieldsMap, ptrDests, isStruct, err := setupElementPtrs(db, t, indirectType, columns)
-	if err != nil {
-		return err
-	}
-
-	i := 0
-	for rows.Next() {
-		el := reflect.New(t).Elem()
-		switch indirectType {
-		case mapRowType:
-			el.Set(reflect.MakeMapWithSize(mapRowType, len(columns)))
-		case sliceRowType:
-			el.Set(reflect.MakeSlice(reflect.SliceOf(t.Elem()), len(columns), len(columns)))
-		}
-
-		updateElementPtrs(el, &ptrs, jsonFields, columns, fieldsMap, ptrDests)
-
-		err = rows.Scan(ptrs...)
-		if err != nil {
-			return err
-		}
-
-		for _, dest := range ptrDests {
-			if err := dest.assign(); err != nil {
-				return err
-			}
-		}
-
-		indirectEl := reflect.Indirect(el)
-
-		if indirectType == mapRowType {
-			// our map row is actually a map to pointers, not actual values, since
-			// you can't take the address of a value by map and key, so we need to fix that here
-			// to make usage intuitive
-
-			for _, k := range indirectEl.MapKeys() {
-				indirectEl.SetMapIndex(k, indirectEl.MapIndex(k).Elem().Elem())
-			}
-		}
-
-		for _, jsonField := range jsonFields {
-			if len(jsonField.j) == 0 {
-				continue
-			}
-
-			if !isStruct {
-				err = json.Unmarshal(jsonField.j, el.Interface())
-				if err != nil {
-					return fmt.Errorf("failed to unmarshal json into dest: %w", err)
-				}
-			} else {
-				f := indirectEl.FieldByIndex(jsonField.index)
-				err = json.Unmarshal(jsonField.j, f.Addr().Interface())
-				if err != nil {
-					return fmt.Errorf("failed to unmarshal json into struct field %q: %w", indirectEl.Type().FieldByIndex(jsonField.index).Name, err)
-				}
-			}
-		}
-
-		if len(cacheKey) != 0 {
-			cacheSlice = reflect.Append(cacheSlice, el)
-		}
-
-		i++
-
-		if err = sendElement(el); err != nil {
-			return err
-		}
-		if !multiRow {
-			break
-		}
-	}
-	if err = rows.Err(); err != nil {
-		return err
-	}
-
-	if !multiRow && i == 0 {
+	if !multiRow && rowCount == 0 {
 		return sql.ErrNoRows
 	}
 

--- a/select.go
+++ b/select.go
@@ -264,14 +264,23 @@ func (db *Database) query(conn handlerWithContext, ctx context.Context, dest any
 	// already out the door; they keep establishment-only retry.
 	retryable := destKind != reflect.Chan && destKind != reflect.Func
 
-	// resetAccumulator discards partially-collected results before a
-	// mid-stream retry so the re-run starts from a clean slate.
+	// initialSliceLen is the caller-supplied length of a slice dest before the
+	// query runs. Select appends results onto whatever the caller passed in, so
+	// a mid-stream retry must truncate back to this length — not zero — to keep
+	// any pre-existing elements the caller is accumulating into.
+	var initialSliceLen int
+	if multiRow && destKind == reflect.Slice {
+		initialSliceLen = destRef.Elem().Len()
+	}
+
+	// resetAccumulator discards the partial results collected on a failed
+	// attempt before a mid-stream retry so the re-run starts from the caller's
+	// pre-query state. Only slice dests accumulate across rows; single (*T)
+	// dests Set exactly once after a full row scan, which a mid-stream drop
+	// can't reach, so they need no reset.
 	resetAccumulator := func() {
-		switch {
-		case multiRow && destKind == reflect.Slice:
-			destRef.Elem().Set(reflect.MakeSlice(destRef.Elem().Type(), 0, 0))
-		case !multiRow:
-			destRef.Elem().Set(reflect.Zero(destRef.Elem().Type()))
+		if multiRow && destKind == reflect.Slice {
+			destRef.Elem().Set(destRef.Elem().Slice(0, initialSliceLen))
 		}
 		if cacheDuration > 0 {
 			cacheSlice = reflect.New(reflect.SliceOf(t)).Elem()

--- a/select_test.go
+++ b/select_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"reflect"
 	"regexp"
 	"sync"
@@ -839,4 +840,123 @@ func TestSelectFailsWhenInitialConnAcquireFails(t *testing.T) {
 	err = db.Select(&v, "SELECT 1", 0)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to get connection")
+}
+
+// TestSelectRetriesMidStreamConnDrop verifies that a buffered (slice) dest
+// whose connection drops *mid-stream* — after rows have started flowing — is
+// retried and succeeds within the existing retry budget. Before the fix the
+// retry only wrapped query establishment, so a drop during scanning surfaced
+// straight to the caller. The partial first-attempt row must be discarded so
+// the result reflects only the successful re-run.
+func TestSelectRetriesMidStreamConnDrop(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	// First attempt: one good row, then the connection dies on the 2nd row.
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).
+			AddRow(int64(1)).
+			AddRow(int64(2)).
+			RowError(1, mysql.ErrInvalidConn),
+	)
+	// Retry on a fresh conn returns a clean result set.
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).
+			AddRow(int64(10)).
+			AddRow(int64(20)),
+	)
+
+	var ns []int64
+	require.NoError(t, db.Select(&ns, "SELECT n", 0))
+	require.Equal(t, []int64{10, 20}, ns)
+}
+
+// TestSelectRetriesMidStreamSingleDest covers the single-value (*T) buffered
+// dest: a mid-stream drop discards the partial result and the re-run wins.
+func TestSelectRetriesMidStreamSingleDest(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).
+			AddRow(int64(1)).
+			RowError(0, mysql.ErrInvalidConn),
+	)
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).AddRow(int64(42)),
+	)
+
+	var v int64
+	require.NoError(t, db.Select(&v, "SELECT n", 0))
+	require.Equal(t, int64(42), v)
+}
+
+// TestSelectDoesNotRetryMidStreamNonConnError verifies a non-transient
+// mid-stream error (anything that isn't ErrInvalidConn / ErrBadConn) is not
+// retried and surfaces immediately. Only one query is issued.
+func TestSelectDoesNotRetryMidStreamNonConnError(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	boom := errors.New("mid-stream type error")
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).
+			AddRow(int64(1)).
+			AddRow(int64(2)).
+			RowError(1, boom),
+	)
+
+	var ns []int64
+	err := db.Select(&ns, "SELECT n", 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, boom)
+}
+
+// TestSelectChannelDestDoesNotRetryMidStream verifies channel dests keep
+// establishment-only retry semantics: rows are emitted to the caller as they
+// are scanned, so a mid-stream drop can't be re-run and surfaces as-is. Only
+// one query is issued and the already-streamed row stays visible.
+func TestSelectChannelDestDoesNotRetryMidStream(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).
+			AddRow(int64(1)).
+			AddRow(int64(2)).
+			RowError(1, mysql.ErrInvalidConn),
+	)
+
+	ch := make(chan int64, 10)
+	err := db.Select(ch, "SELECT n", 0)
+	close(ch)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, mysql.ErrInvalidConn)
+
+	var got []int64
+	for v := range ch {
+		got = append(got, v)
+	}
+	require.Equal(t, []int64{1}, got)
+}
+
+// TestExistsRetriesMidStreamConnDrop verifies Exists re-runs the query when
+// the connection drops during the single-row read phase.
+func TestExistsRetriesMidStreamConnDrop(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectQuery("^SELECT 1$").WillReturnRows(
+		sqlmock.NewRows([]string{"1"}).
+			AddRow(int64(1)).
+			RowError(0, mysql.ErrInvalidConn),
+	)
+	mock.ExpectQuery("^SELECT 1$").WillReturnRows(
+		sqlmock.NewRows([]string{"1"}).AddRow(int64(1)),
+	)
+
+	exists, err := db.Exists("SELECT 1", 0)
+	require.NoError(t, err)
+	require.True(t, exists)
 }

--- a/select_test.go
+++ b/select_test.go
@@ -986,3 +986,68 @@ func TestExistsRetriesMidStreamConnDrop(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 }
+
+// TestExistsRetriesEstablishmentConnDrop guards against a silent false
+// negative: when QueryContext fails with ErrInvalidConn on a healthy pool,
+// exists must re-run the query (the next QueryContext draws a fresh pooled
+// conn) rather than reporting a dead conn as "no rows". Returning db.Test()
+// directly would return (false, nil) and stop the retry.
+func TestExistsRetriesEstablishmentConnDrop(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectQuery("^SELECT 1$").WillReturnError(mysql.ErrInvalidConn)
+	mock.ExpectQuery("^SELECT 1$").WillReturnRows(
+		sqlmock.NewRows([]string{"1"}).AddRow(int64(1)),
+	)
+
+	exists, err := db.Exists("SELECT 1", 0)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+// TestExistsTxFailsFastOnEstablishmentConnDrop verifies that an ErrInvalidConn
+// inside a transaction is not retried — the tx is bound to its dead conn and
+// can't be resumed on a fresh one, so it must surface immediately.
+func TestExistsTxFailsFastOnEstablishmentConnDrop(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("^SELECT 1$").WillReturnError(mysql.ErrInvalidConn)
+	mock.ExpectRollback()
+
+	tx, _, err := db.BeginTx()
+	require.NoError(t, err)
+
+	_, err = tx.Exists("SELECT 1", 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, mysql.ErrInvalidConn)
+
+	require.NoError(t, tx.Cancel())
+}
+
+// TestExistsTxFailsFastOnMidStreamConnDrop covers the same tx fail-fast for a
+// connection that drops during the single-row read rather than at
+// establishment.
+func TestExistsTxFailsFastOnMidStreamConnDrop(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("^SELECT 1$").WillReturnRows(
+		sqlmock.NewRows([]string{"1"}).
+			AddRow(int64(1)).
+			RowError(0, mysql.ErrInvalidConn),
+	)
+	mock.ExpectRollback()
+
+	tx, _, err := db.BeginTx()
+	require.NoError(t, err)
+
+	_, err = tx.Exists("SELECT 1", 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, mysql.ErrInvalidConn)
+
+	require.NoError(t, tx.Cancel())
+}

--- a/select_test.go
+++ b/select_test.go
@@ -871,6 +871,32 @@ func TestSelectRetriesMidStreamConnDrop(t *testing.T) {
 	require.Equal(t, []int64{10, 20}, ns)
 }
 
+// TestSelectRetriesMidStreamPreservesExistingSlice verifies that a mid-stream
+// retry discards only the rows collected on the failed attempt, not the
+// elements the caller had already accumulated into the slice. Select appends
+// onto the passed-in slice, so the reset must truncate back to the caller's
+// pre-query length rather than emptying it.
+func TestSelectRetriesMidStreamPreservesExistingSlice(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).
+			AddRow(int64(1)).
+			AddRow(int64(2)).
+			RowError(1, mysql.ErrInvalidConn),
+	)
+	mock.ExpectQuery("^SELECT n$").WillReturnRows(
+		sqlmock.NewRows([]string{"n"}).
+			AddRow(int64(10)).
+			AddRow(int64(20)),
+	)
+
+	ns := []int64{99}
+	require.NoError(t, db.Select(&ns, "SELECT n", 0))
+	require.Equal(t, []int64{99, 10, 20}, ns)
+}
+
 // TestSelectRetriesMidStreamSingleDest covers the single-value (*T) buffered
 // dest: a mid-stream drop discards the partial result and the re-run wins.
 func TestSelectRetriesMidStreamSingleDest(t *testing.T) {


### PR DESCRIPTION
Closes #163

## Problem

`Select` (`query()`) and `Exists` retried a dropped/dead MySQL connection **only at query establishment** — the `backoff.Retry` wrapped just the `conn.QueryContext` call. The entire row-streaming phase (`rows.Next()` / `rows.Scan()` / `rows.Err()`) ran *after* the retry returned, **outside** it. So a connection that died **mid-stream** surfaced straight to the caller as `invalid connection` / `driver: bad connection` and was **never retried**, even though the read is safe to re-run.

For short queries this is rarely hit (the drop almost always lands at establishment, which *is* retried). For **heavy, long-running** reads it's the dominant failure mode — the connection is held for the whole streaming phase, which is precisely when a server-side timeout / proxy reset / pooled-conn death occurs (real incident: StirlingMarketingGroup#5648).

## Fix

Restructure `query()` so that, for **buffered dests** (slice `*[]T` and single `*T`), the query *and* its scan loop run inside the retry:

- Extracted the connection-recovery logic into a shared `swapConn` helper (reconnect-if-pool-down → release the dead dedicated conn → reacquire a fresh one), reused by both establishment and mid-stream paths.
- On a mid-stream `mysql.ErrInvalidConn` / `driver.ErrBadConn`, discard the partial result (`resetAccumulator`) and re-run the whole query on a fresh conn within the same backoff / `MaxAttempts` / `MaxExecutionTime` budget.
- `resetAccumulator` truncates a slice dest back to the caller's **pre-query length** (Select appends onto the passed-in slice), so pre-existing elements are preserved.

**Design constraint — only buffered dests can be retried.** A mid-stream retry means discarding partial results and re-running, which is only safe when the caller hasn't observed any rows yet:

- **slice / single dests** accumulate into `destRef.Elem()` and aren't visible until `query()` returns → **safe**, retried.
- **channel / func dests** emit each row via `sendElement` as it's scanned → rows are already out the door → **NOT safe**; they keep establishment-only retry (now documented).

`Exists` gets the same single-row treatment.

Only `mysql.ErrInvalidConn` / `driver.ErrBadConn` trigger the mid-stream re-run; everything else stays `backoff.Permanent`.

## Tests

Deterministic via sqlmock `RowError` (no racy `KILL` needed):

- buffered slice + single dest: mid-stream drop is retried and succeeds
- pre-populated slice: mid-stream retry preserves the caller's existing elements
- non-transient mid-stream error: surfaces immediately, not retried
- channel dest: unchanged — establishment-only, partial row stays visible
- `Exists`: mid-stream drop retried and succeeds

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -covermode=atomic ./...` — pass (65.2% coverage)
- `golangci-lint run` — 0 issues

## Note

A re-run costs the whole query and the budget is bounded by `MaxExecutionTime`, so callers should still keep individual heavy reads reasonably small (e.g. chunked) — this fix makes a transient drop *recoverable* rather than fatal, it doesn't remove that need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)