### PR TITLE
Skip tx deadlock replay when the retry budget is spent

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -66,6 +66,18 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 					return backoff.Permanent(err)
 				}
 
+				// the deadlock rolled back the whole transaction AND ended it on
+				// the session, so anything executed on this connection from here
+				// on runs in autocommit mode. The replay below is only sound when
+				// a retry of the failing statement follows to resume the work; if
+				// the retry budget is already spent, replaying would commit each
+				// recorded query individually outside any transaction — beyond
+				// the reach of the caller's eventual rollback — leaving phantom
+				// rows. Surface the deadlock as-is instead.
+				if MaxAttempts > 0 && attempt >= MaxAttempts {
+					return backoff.Permanent(err)
+				}
+
 				// deadlock occurred, which means *every* query in this transaction
 				// was rolled back, so we need to run them all again
 				tx.updates.RLock()

--- a/exec_test.go
+++ b/exec_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
 	"testing"
+
+	stdMysql "github.com/go-sql-driver/mysql"
 )
 
 type stubResult struct{}
@@ -48,5 +51,90 @@ func TestExecRespectsMaxAttempts(t *testing.T) {
 	}
 	if h.calls != MaxAttempts {
 		t.Fatalf("expected %d attempts, got %d", MaxAttempts, h.calls)
+	}
+}
+
+// recordingExecHandler records every query it receives and fails with the
+// scripted error (by call index) when one is set.
+type recordingExecHandler struct {
+	queries []string
+	errors  []error
+}
+
+func (h *recordingExecHandler) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	h.queries = append(h.queries, query)
+	if i := len(h.queries) - 1; i < len(h.errors) && h.errors[i] != nil {
+		return nil, h.errors[i]
+	}
+	return stubResult{}, nil
+}
+
+func (h *recordingExecHandler) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	panic("unexpected QueryContext call in recordingExecHandler")
+}
+
+func newDeadlockTestTx() *Tx {
+	return &Tx{
+		updates: &struct {
+			sync.RWMutex
+			queries []string
+		}{queries: []string{"update `t` set `a` = 1"}},
+	}
+}
+
+var errTestDeadlock = &stdMysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock; try restarting transaction"}
+
+// A 1213 rolls back the whole transaction AND ends it on the session, so
+// anything executed on the connection afterwards runs in autocommit mode.
+// When no retry will follow, replaying the recorded tx queries would commit
+// each of them individually outside any transaction — beyond the reach of
+// the caller's eventual rollback. The replay must be skipped.
+func TestExecDeadlockReplaySkippedWhenNoRetryBudget(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 1
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	h := &recordingExecHandler{errors: []error{errTestDeadlock}}
+
+	db := &Database{}
+	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	if err == nil {
+		t.Fatal("expected the deadlock error to surface")
+	}
+	var mysqlErr *stdMysql.MySQLError
+	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1213 {
+		t.Fatalf("expected error 1213, got %v", err)
+	}
+	if len(h.queries) != 1 {
+		t.Fatalf("expected only the original statement (no replays) with no retry budget, got %q", h.queries)
+	}
+}
+
+// With retry budget left the replay must still run, followed by the retry of
+// the original statement, so the transaction resumes where it left off.
+func TestExecDeadlockReplayRunsWithRetryBudget(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 3
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	h := &recordingExecHandler{errors: []error{errTestDeadlock}}
+
+	db := &Database{}
+	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	if err != nil {
+		t.Fatalf("expected the replay + retry to recover, got %v", err)
+	}
+	want := []string{
+		"insert into `t` (`a`) values (2)",
+		"update `t` set `a` = 1",
+		"insert into `t` (`a`) values (2)",
+	}
+	if len(h.queries) != len(want) {
+		t.Fatalf("expected queries %q, got %q", want, h.queries)
+	}
+	for i := range want {
+		if h.queries[i] != want[i] {
+			t.Fatalf("expected queries %q, got %q", want, h.queries)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

When a statement inside a transaction hits a 1213 deadlock, `exec`'s `handleDeadlock` replays every recorded update query of that tx on the same connection so a retry of the failing statement can resume the transaction's work.

But the 1213 rolled back the victim's **whole transaction and ended it on the session** — everything executed on that connection afterwards runs in **autocommit mode**. When no retry follows (retry budget already spent, e.g. `MaxAttempts = 1`), the replay commits each recorded query individually outside any transaction, beyond the reach of the caller's eventual rollback. Phantom rows.

## Real-world impact

StirlingMarketingGroup CI sets `MaxAttempts = 1` in tests and retries deadlocked transactions at the caller level (`retryOnDeadlock` and friends). When a prepay-deposit handler tx deadlocked on its `quoteorders` insert, the replay autocommitted the tx's earlier `orderlineitems` insert; the caller's retry then inserted it again → duplicate line items → flaky `TestQuotePrepayDeposit` (expected 2 line items, got 3).

## Fix

In `handleDeadlock`, skip the replay and surface the deadlock as permanent when `attempt >= MaxAttempts` — there is no retry coming, so replaying is pure harm. Replay behavior with retry budget remaining is unchanged (covered by the new `TestExecDeadlockReplayRunsWithRetryBudget`).

## Tests

- `TestExecDeadlockReplaySkippedWhenNoRetryBudget` — fails before the fix (replay ran), passes after
- `TestExecDeadlockReplayRunsWithRetryBudget` — pins the preserved replay+retry sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)