### PR TITLE
Re-open the transaction before deadlock replay to restore atomicity (#166)

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -54,49 +54,68 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 			Error:        err,
 		})
 		if err != nil {
-			var handleDeadlock func(err error) error
-			handleDeadlock = func(err error) error {
-				if tx == nil || !checkDeadlockError(err) {
-					return nil
-				}
-
-				// if this is a tx replay query already, we don't want it running all of the queries back
-				// again, so we just return the error immediately to left the top level retry loop handle it
+			// A deadlock (1213) rolls back the whole transaction AND ends it on
+			// the session, so the connection is back in autocommit mode and
+			// anything run on it from here commits piecewise.
+			if tx != nil && checkDeadlockError(err) {
+				// A replayed statement (newQuery=false) that deadlocks must not
+				// be retried inline — that retry would run in autocommit. Surface
+				// it so the top-level reconstruction below re-opens the tx and
+				// replays from the top.
 				if !newQuery {
-					return backoff.Permanent(err)
+					return nil, backoff.Permanent(err)
 				}
 
-				// the deadlock rolled back the whole transaction AND ended it on
-				// the session, so anything executed on this connection from here
-				// on runs in autocommit mode. The replay below is only sound when
-				// a retry of the failing statement follows to resume the work; if
-				// the retry budget is already spent, replaying would commit each
-				// recorded query individually outside any transaction — beyond
-				// the reach of the caller's eventual rollback — leaving phantom
-				// rows. Surface the deadlock as-is instead.
-				if MaxAttempts > 0 && attempt >= MaxAttempts {
-					return backoff.Permanent(err)
-				}
-
-				// deadlock occurred, which means *every* query in this transaction
-				// was rolled back, so we need to run them all again
-				tx.updates.RLock()
-				defer tx.updates.RUnlock()
-
-				for _, q := range tx.updates.queries {
-					_, err := db.exec(conn, ctx, nil, false, q)
-					if err := handleDeadlock(err); err != nil {
-						return err
+				// Reconstruct the rolled-back transaction before the failing
+				// statement is retried: re-open it and replay every recorded
+				// query, so the replay, the retry, and the rest of the caller's
+				// work ride a real transaction again — otherwise each commits
+				// piecewise in autocommit and the caller's eventual
+				// COMMIT/ROLLBACK is a no-op, stranding partial state beyond the
+				// reach of a rollback.
+				//
+				// Replaying is only sound when a retry of the failing statement
+				// follows; once the retry budget is spent the replay would commit
+				// the recorded queries individually outside any transaction, so
+				// surface the deadlock as-is instead (#165). A deadlock during the
+				// replay ends the session's tx again, so re-open and restart;
+				// each restart counts against that same budget, and
+				// MaxExecutionTime bounds the loop when attempts are uncapped.
+				for restart := 0; ; restart++ {
+					if MaxAttempts > 0 && attempt+restart >= MaxAttempts {
+						return nil, backoff.Permanent(err)
 					}
-					if err != nil {
-						return err
+					if db.MaxExecutionTime > 0 && time.Since(start) >= db.MaxExecutionTime {
+						return nil, backoff.Permanent(err)
+					}
+
+					startTxStart := time.Now()
+					_, startTxErr := conn.ExecContext(ctx, "start transaction")
+					startTx, _ := conn.(*sql.Tx)
+					db.callLog(LogDetail{
+						Query:    "start transaction",
+						Duration: time.Since(startTxStart),
+						Tx:       startTx,
+						Attempt:  1,
+						Error:    startTxErr,
+					})
+					if startTxErr != nil {
+						return nil, backoff.Permanent(startTxErr)
+					}
+
+					replayErr := db.replayTx(conn, ctx, tx)
+					if replayErr == nil {
+						break
+					}
+					// only a replay deadlock is recoverable by re-opening and
+					// replaying again; any other failure is terminal.
+					if !checkDeadlockError(replayErr) {
+						return nil, backoff.Permanent(replayErr)
 					}
 				}
 
-				// return the original deadlock error to resume regular functionality of the retry loop
-				return err
-			}
-			if err := handleDeadlock(err); err != nil {
+				// resume the outer retry loop so the failing statement runs
+				// again inside the reconstructed transaction
 				return nil, err
 			}
 
@@ -137,4 +156,21 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 	}
 
 	return res, nil
+}
+
+// replayTx replays every recorded statement of tx on conn, which must already
+// have a fresh transaction open. Replays pass newQuery=false so they are not
+// re-recorded and a deadlock on one surfaces (rather than being retried inline
+// in autocommit) for the caller to recover by re-opening and replaying again.
+func (db *Database) replayTx(conn handlerWithContext, ctx context.Context, tx *Tx) error {
+	tx.updates.RLock()
+	defer tx.updates.RUnlock()
+
+	for _, q := range tx.updates.queries {
+		if _, err := db.exec(conn, ctx, tx, false, q); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -110,8 +110,12 @@ func TestExecDeadlockReplaySkippedWhenNoRetryBudget(t *testing.T) {
 	}
 }
 
-// With retry budget left the replay must still run, followed by the retry of
-// the original statement, so the transaction resumes where it left off.
+// With retry budget left the replay must still run, but only after a fresh
+// `start transaction` re-opens the session the deadlock ended — otherwise the
+// replay and the retried statement would commit piecewise in autocommit mode
+// and the caller's eventual COMMIT/ROLLBACK would be meaningless. The retry of
+// the original statement then follows so the transaction resumes where it left
+// off.
 func TestExecDeadlockReplayRunsWithRetryBudget(t *testing.T) {
 	originalMax := MaxAttempts
 	MaxAttempts = 3
@@ -126,11 +130,82 @@ func TestExecDeadlockReplayRunsWithRetryBudget(t *testing.T) {
 	}
 	want := []string{
 		"insert into `t` (`a`) values (2)",
+		"start transaction",
 		"update `t` set `a` = 1",
 		"insert into `t` (`a`) values (2)",
 	}
 	if len(h.queries) != len(want) {
 		t.Fatalf("expected queries %q, got %q", want, h.queries)
+	}
+	for i := range want {
+		if h.queries[i] != want[i] {
+			t.Fatalf("expected queries %q, got %q", want, h.queries)
+		}
+	}
+}
+
+// A deadlock raised by a replayed statement ends the re-opened transaction on
+// the session again, so it must not be retried inline (that retry would run in
+// autocommit). Instead the whole reconstruction restarts: a second `start
+// transaction` re-opens the tx before the recorded queries are replayed again.
+func TestExecDeadlockReplayReopensWhenReplayDeadlocks(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 3
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	// call 0: original insert deadlocks; call 1: first `start transaction`;
+	// call 2: replayed update deadlocks; the reconstruction restarts.
+	h := &recordingExecHandler{errors: []error{errTestDeadlock, nil, errTestDeadlock}}
+
+	db := &Database{}
+	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	if err != nil {
+		t.Fatalf("expected the replay restart + retry to recover, got %v", err)
+	}
+	want := []string{
+		"insert into `t` (`a`) values (2)",
+		"start transaction",
+		"update `t` set `a` = 1", // replay deadlocks
+		"start transaction",      // reconstruction restarts before replaying again
+		"update `t` set `a` = 1", // replay succeeds
+		"insert into `t` (`a`) values (2)",
+	}
+	if len(h.queries) != len(want) {
+		t.Fatalf("expected queries %q, got %q", want, h.queries)
+	}
+	for i := range want {
+		if h.queries[i] != want[i] {
+			t.Fatalf("expected queries %q, got %q", want, h.queries)
+		}
+	}
+}
+
+// If re-opening the transaction fails, the replay must not run — committing the
+// recorded queries in autocommit mode is exactly what the re-open prevents — so
+// the start-transaction error surfaces and no recorded query is replayed.
+func TestExecDeadlockReplayAbortsWhenReopenFails(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 3
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	reopenErr := errors.New("connection is dead")
+	// call 0 is the original statement (deadlock); call 1 is `start transaction`.
+	h := &recordingExecHandler{errors: []error{errTestDeadlock, reopenErr}}
+
+	db := &Database{}
+	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	if err == nil {
+		t.Fatal("expected the re-open failure to surface")
+	}
+	if !errors.Is(err, reopenErr) {
+		t.Fatalf("expected the start-transaction error, got %v", err)
+	}
+	want := []string{
+		"insert into `t` (`a`) values (2)",
+		"start transaction",
+	}
+	if len(h.queries) != len(want) {
+		t.Fatalf("expected no replay after a failed re-open, got %q", h.queries)
 	}
 	for i := range want {
 		if h.queries[i] != want[i] {

--- a/exec_test.go
+++ b/exec_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	stdMysql "github.com/go-sql-driver/mysql"
 )
@@ -211,5 +212,67 @@ func TestExecDeadlockReplayAbortsWhenReopenFails(t *testing.T) {
 		if h.queries[i] != want[i] {
 			t.Fatalf("expected queries %q, got %q", want, h.queries)
 		}
+	}
+}
+
+// A non-deadlock failure during replay can't be recovered by re-opening and
+// replaying again, so it is terminal: the reconstruction stops and the error
+// surfaces instead of looping.
+func TestExecDeadlockReplayAbortsOnNonDeadlockReplayFailure(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 3
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	replayErr := errors.New("table is gone")
+	// call 0: original insert deadlocks; call 1: `start transaction`; call 2:
+	// replayed update fails with a non-deadlock, terminal error.
+	h := &recordingExecHandler{errors: []error{errTestDeadlock, nil, replayErr}}
+
+	db := &Database{}
+	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	if err == nil {
+		t.Fatal("expected the non-deadlock replay failure to surface")
+	}
+	if !errors.Is(err, replayErr) {
+		t.Fatalf("expected the replay error, got %v", err)
+	}
+	want := []string{
+		"insert into `t` (`a`) values (2)",
+		"start transaction",
+		"update `t` set `a` = 1", // replay fails terminally — no restart
+	}
+	if len(h.queries) != len(want) {
+		t.Fatalf("expected the replay to abort, got %q", h.queries)
+	}
+	for i := range want {
+		if h.queries[i] != want[i] {
+			t.Fatalf("expected queries %q, got %q", want, h.queries)
+		}
+	}
+}
+
+// When attempts are uncapped (MaxAttempts == 0), MaxExecutionTime must bound the
+// reconstruction loop so a persistently deadlocking replay can't spin forever.
+// With the budget already exhausted the deadlock surfaces before any replay.
+func TestExecDeadlockReplayBoundedByMaxExecutionTime(t *testing.T) {
+	originalMax := MaxAttempts
+	MaxAttempts = 0 // uncapped — only MaxExecutionTime can bound the loop
+	t.Cleanup(func() { MaxAttempts = originalMax })
+
+	h := &recordingExecHandler{errors: []error{errTestDeadlock}}
+
+	// any elapsed time exceeds a 1ns budget, so the loop aborts on its first
+	// pass before re-opening the transaction.
+	db := &Database{MaxExecutionTime: time.Nanosecond}
+	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	if err == nil {
+		t.Fatal("expected the deadlock error to surface")
+	}
+	var mysqlErr *stdMysql.MySQLError
+	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1213 {
+		t.Fatalf("expected error 1213, got %v", err)
+	}
+	if len(h.queries) != 1 {
+		t.Fatalf("expected the time budget to abort before any replay, got %q", h.queries)
 	}
 }


### PR DESCRIPTION
Closes #166. Follow-up to #165.

## Problem

A 1213 deadlock rolls back the victim's whole transaction **and ends it on the session**, dropping the connection into autocommit. When `exec`'s deadlock handler replayed the recorded tx queries (with retry budget left), the replay, the retried statement, and every later statement of that "transaction" ran in **autocommit** — committing piecewise. The caller's eventual `COMMIT`/`ROLLBACK` became a no-op:

- A later failure (e.g. a card charge declined after earlier writes) could not be undone — partial state persisted.
- The `FOR UPDATE` serialization the caller established was gone.

## Fix

Re-open a real transaction with `start transaction` on the connection **before replaying**, so the replay, the retry, and the rest of the caller's work ride a transaction again. This is sound with `database/sql` because a `*sql.Tx` holds its dedicated connection for the tx's whole lifetime, so the later `Tx.Commit`/`Rollback` delegates `COMMIT`/`ROLLBACK` to that same re-opened transaction.

While fixing this, a deeper instance of the same bug surfaced (caught in review): the old replay loop passed a **nil** tx, so a deadlock on a *replayed* statement was retried **inline in autocommit** (the not-a-new-query "permanent" branch was unreachable). The handler is now an **iterative reconstruction**:

- Replayed statements pass the tx (`newQuery=false`), so a replay-time deadlock **surfaces** instead of inline-retrying in autocommit.
- On a replay deadlock, the reconstruction re-opens and replays from the top.
- Bounded like the outer retry loop: each restart counts against `MaxAttempts` (preserving the #165 no-budget skip at restart 0), and `MaxExecutionTime` bounds it when attempts are uncapped. Iteration (not recursion) keeps it memory-safe under a pathological repeated-replay deadlock.

Re-acquiring `SELECT ... FOR UPDATE` locks taken earlier in the tx still needs select-recording and is left for a separate change (as the issue noted).

## Tests

- `TestExecDeadlockReplayRunsWithRetryBudget` — updated: `start transaction` now precedes the replay.
- `TestExecDeadlockReplayReopensWhenReplayDeadlocks` — new: a deadlock *during* replay triggers a second `start transaction` before replaying again.
- `TestExecDeadlockReplayAbortsWhenReopenFails` — new: a failed re-open surfaces and **no** recorded query is replayed.
- `TestExecDeadlockReplaySkippedWhenNoRetryBudget` — unchanged (#165 behavior preserved).

`go vet`, `go test -race ./...`, and `golangci-lint` all clean. Reviewed with GPT-5.5 (2 rounds, no remaining findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)