### PR TITLE
Surface mid-tx deadlocks instead of replaying writes in autocommit (#167)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,9 @@ Every read path (`query` in select.go) and write path (`exec` in exec.go) runs t
 4. `backoff.Retry` with exponential backoff bounded by `MaxExecutionTime` and optionally `MaxAttempts`. Retryable MySQL error numbers are enumerated in `checkRetryError` (error.go:60) — 1213 (deadlock), 1205, 2006, 2003, 1047, 1452, 1317, 1146, 1305, 1105.
 5. `backoff.PermanentError` is an **internal** signal only — `unwrapBackoffPermanent` must strip it before returning so callers' own `backoff.Retry` loops aren't hijacked. This was added in commit f2d0b1b; preserve this invariant when touching exec/select/exists.
 
-### Transactions and deadlock replay
+### Transactions and deadlock handling
 
-`Tx` (tx.go) tracks every `exec` call's replaced query in `tx.updates.queries`. On a 1213 deadlock mid-transaction, the `handleDeadlock` closure in exec.go replays every prior query on the same `*sql.Tx` before returning the error, so the outer `backoff.Retry` can retry the *current* statement against a state equivalent to before the deadlock. Replayed queries pass `newQuery=false` so they don't re-append to `updates.queries` and don't recurse into their own replay. Only `Exec`-style queries are tracked; `Select` is not.
+A 1213 deadlock is retryable in autocommit (`checkRetryError` lists it), but **inside an explicit transaction it is not retried**: a deadlock rolls back *and* ends the whole transaction on the session, leaving the connection in autocommit mode. The `exec` deadlock guard (`tx != nil && checkDeadlockError(err)`) returns `backoff.Permanent(err)` so the deadlock surfaces to the caller unchanged. The caller must restart the whole transaction from `Begin` — the only way to preserve atomicity, including any non-recorded `Select ... FOR UPDATE` locks and read-snapshot state. Earlier versions replayed the transaction's recorded writes (in autocommit, then later inside a re-opened tx); both were unsound and were removed in #167 — do not reintroduce mid-tx replay.
 
 `PostCommitHooks` fire only after a successful `Commit`. `PostRollbackHooks` fire after a rollback via `Cancel()` but **not** when `Cancel()` runs after a successful commit (detected via `sql.ErrTxDone`).
 

--- a/backoff_permanent_test.go
+++ b/backoff_permanent_test.go
@@ -47,7 +47,7 @@ func TestExecDoesNotLeakPermanentError(t *testing.T) {
 	h := &failingExecHandler{errors: []error{errPermanentProbe}}
 
 	db := &Database{}
-	_, err := db.exec(h, context.Background(), nil, true, "SELECT 1")
+	_, err := db.exec(h, context.Background(), nil, "SELECT 1")
 	assertNoPermanentWrapper(t, err)
 }
 

--- a/database.go
+++ b/database.go
@@ -621,7 +621,7 @@ func (db *Database) InsertReadsContext(ctx context.Context, insert string, sourc
 
 // ExecContext executes a query and nothing more
 func (db *Database) ExecContextResult(ctx context.Context, query string, params ...any) (sql.Result, error) {
-	return db.exec(db.Writes, ctx, nil, true, query, params...)
+	return db.exec(db.Writes, ctx, nil, query, params...)
 }
 
 // ExecContext executes a query and nothing more

--- a/exec.go
+++ b/exec.go
@@ -14,8 +14,7 @@ import (
 )
 
 // exec executes a query and nothing more
-// newQuery is true if this is a new query, false if it's a replay of a query in a transaction
-func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, newQuery bool, query string, params ...any) (sql.Result, error) {
+func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, query string, params ...any) (sql.Result, error) {
 	replacedQuery, normalizedParams, err := db.interpolateParams(query, params...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to interpolate params: %w", err)
@@ -54,69 +53,17 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 			Error:        err,
 		})
 		if err != nil {
-			// A deadlock (1213) rolls back the whole transaction AND ends it on
-			// the session, so the connection is back in autocommit mode and
-			// anything run on it from here commits piecewise.
+			// Within an explicit transaction a deadlock (1213) rolls back AND
+			// ends the whole transaction on the session, leaving the connection
+			// in autocommit mode. We cannot transparently retry: re-running the
+			// failing statement — or replaying the transaction's earlier writes —
+			// would execute in autocommit and commit piecewise, outside the
+			// caller's transaction and beyond the reach of its eventual
+			// COMMIT/ROLLBACK, stranding phantom rows. The only way to preserve
+			// atomicity is for the caller to restart the whole transaction from
+			// Begin, so surface the deadlock instead of retrying it (#167).
 			if tx != nil && checkDeadlockError(err) {
-				// A replayed statement (newQuery=false) that deadlocks must not
-				// be retried inline — that retry would run in autocommit. Surface
-				// it so the top-level reconstruction below re-opens the tx and
-				// replays from the top.
-				if !newQuery {
-					return nil, backoff.Permanent(err)
-				}
-
-				// Reconstruct the rolled-back transaction before the failing
-				// statement is retried: re-open it and replay every recorded
-				// query, so the replay, the retry, and the rest of the caller's
-				// work ride a real transaction again — otherwise each commits
-				// piecewise in autocommit and the caller's eventual
-				// COMMIT/ROLLBACK is a no-op, stranding partial state beyond the
-				// reach of a rollback.
-				//
-				// Replaying is only sound when a retry of the failing statement
-				// follows; once the retry budget is spent the replay would commit
-				// the recorded queries individually outside any transaction, so
-				// surface the deadlock as-is instead (#165). A deadlock during the
-				// replay ends the session's tx again, so re-open and restart;
-				// each restart counts against that same budget, and
-				// MaxExecutionTime bounds the loop when attempts are uncapped.
-				for restart := 0; ; restart++ {
-					if MaxAttempts > 0 && attempt+restart >= MaxAttempts {
-						return nil, backoff.Permanent(err)
-					}
-					if db.MaxExecutionTime > 0 && time.Since(start) >= db.MaxExecutionTime {
-						return nil, backoff.Permanent(err)
-					}
-
-					startTxStart := time.Now()
-					_, startTxErr := conn.ExecContext(ctx, "start transaction")
-					startTx, _ := conn.(*sql.Tx)
-					db.callLog(LogDetail{
-						Query:    "start transaction",
-						Duration: time.Since(startTxStart),
-						Tx:       startTx,
-						Attempt:  1,
-						Error:    startTxErr,
-					})
-					if startTxErr != nil {
-						return nil, backoff.Permanent(startTxErr)
-					}
-
-					replayErr := db.replayTx(conn, ctx, tx)
-					if replayErr == nil {
-						break
-					}
-					// only a replay deadlock is recoverable by re-opening and
-					// replaying again; any other failure is terminal.
-					if !checkDeadlockError(replayErr) {
-						return nil, backoff.Permanent(replayErr)
-					}
-				}
-
-				// resume the outer retry loop so the failing statement runs
-				// again inside the reconstructed transaction
-				return nil, err
+				return nil, backoff.Permanent(err)
 			}
 
 			if checkRetryError(err) {
@@ -149,28 +96,5 @@ func (db *Database) exec(conn handlerWithContext, ctx context.Context, tx *Tx, n
 		}
 	}
 
-	if tx != nil && newQuery {
-		tx.updates.Lock()
-		defer tx.updates.Unlock()
-		tx.updates.queries = append(tx.updates.queries, replacedQuery)
-	}
-
 	return res, nil
-}
-
-// replayTx replays every recorded statement of tx on conn, which must already
-// have a fresh transaction open. Replays pass newQuery=false so they are not
-// re-recorded and a deadlock on one surfaces (rather than being retried inline
-// in autocommit) for the caller to recover by re-opening and replaying again.
-func (db *Database) replayTx(conn handlerWithContext, ctx context.Context, tx *Tx) error {
-	tx.updates.RLock()
-	defer tx.updates.RUnlock()
-
-	for _, q := range tx.updates.queries {
-		if _, err := db.exec(conn, ctx, tx, false, q); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"sync"
 	"testing"
-	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	stdMysql "github.com/go-sql-driver/mysql"
 )
 
@@ -43,7 +42,7 @@ func TestExecRespectsMaxAttempts(t *testing.T) {
 	}
 
 	db := &Database{}
-	_, err := db.exec(h, context.Background(), nil, true, "SELECT 1")
+	_, err := db.exec(h, context.Background(), nil, "SELECT 1")
 	if err == nil {
 		t.Fatalf("expected error after retries exhausted")
 	}
@@ -74,205 +73,60 @@ func (h *recordingExecHandler) QueryContext(ctx context.Context, query string, a
 	panic("unexpected QueryContext call in recordingExecHandler")
 }
 
-func newDeadlockTestTx() *Tx {
-	return &Tx{
-		updates: &struct {
-			sync.RWMutex
-			queries []string
-		}{queries: []string{"update `t` set `a` = 1"}},
-	}
-}
-
 var errTestDeadlock = &stdMysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock; try restarting transaction"}
 
-// A 1213 rolls back the whole transaction AND ends it on the session, so
-// anything executed on the connection afterwards runs in autocommit mode.
-// When no retry will follow, replaying the recorded tx queries would commit
-// each of them individually outside any transaction — beyond the reach of
-// the caller's eventual rollback. The replay must be skipped.
-func TestExecDeadlockReplaySkippedWhenNoRetryBudget(t *testing.T) {
+// Within an explicit transaction a deadlock (1213) rolls back AND ends the
+// whole transaction on the session, leaving the connection in autocommit mode.
+// cool-mysql must not transparently retry it: re-running the failing statement
+// — or replaying the transaction's earlier writes — would execute in autocommit
+// and commit piecewise outside the caller's transaction, beyond the reach of
+// its eventual COMMIT/ROLLBACK, leaving phantom rows. The deadlock must surface
+// unchanged so the caller can restart the whole transaction from Begin (#167).
+func TestExecTxDeadlockSurfacesWithoutRetry(t *testing.T) {
 	originalMax := MaxAttempts
-	MaxAttempts = 1
+	MaxAttempts = 5 // budget to spare — the deadlock must still not be retried
 	t.Cleanup(func() { MaxAttempts = originalMax })
 
 	h := &recordingExecHandler{errors: []error{errTestDeadlock}}
 
 	db := &Database{}
-	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	_, err := db.exec(h, context.Background(), &Tx{}, "insert into `t` (`a`) values (2)")
 	if err == nil {
 		t.Fatal("expected the deadlock error to surface")
 	}
+
 	var mysqlErr *stdMysql.MySQLError
 	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1213 {
 		t.Fatalf("expected error 1213, got %v", err)
 	}
+	// The backoff.Permanent wrapper used to stop the retry loop must never
+	// leak — it would hijack a caller's own backoff.Retry around the tx.
+	var perm *backoff.PermanentError
+	if errors.As(err, &perm) {
+		t.Fatalf("returned error chain still contains *backoff.PermanentError: %#v", err)
+	}
 	if len(h.queries) != 1 {
-		t.Fatalf("expected only the original statement (no replays) with no retry budget, got %q", h.queries)
+		t.Fatalf("expected the single failing statement with no retry or replay, got %q", h.queries)
 	}
 }
 
-// With retry budget left the replay must still run, but only after a fresh
-// `start transaction` re-opens the session the deadlock ended — otherwise the
-// replay and the retried statement would commit piecewise in autocommit mode
-// and the caller's eventual COMMIT/ROLLBACK would be meaningless. The retry of
-// the original statement then follows so the transaction resumes where it left
-// off.
-func TestExecDeadlockReplayRunsWithRetryBudget(t *testing.T) {
+// Outside a transaction a deadlock is safely retryable: the statement ran in
+// autocommit, so re-running just that statement is sound. The tx-only guard
+// must not suppress that retry.
+func TestExecAutocommitDeadlockStillRetries(t *testing.T) {
 	originalMax := MaxAttempts
 	MaxAttempts = 3
 	t.Cleanup(func() { MaxAttempts = originalMax })
 
+	// deadlock once, then succeed on retry.
 	h := &recordingExecHandler{errors: []error{errTestDeadlock}}
 
 	db := &Database{}
-	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
+	_, err := db.exec(h, context.Background(), nil, "insert into `t` (`a`) values (2)")
 	if err != nil {
-		t.Fatalf("expected the replay + retry to recover, got %v", err)
+		t.Fatalf("expected the autocommit retry to recover, got %v", err)
 	}
-	want := []string{
-		"insert into `t` (`a`) values (2)",
-		"start transaction",
-		"update `t` set `a` = 1",
-		"insert into `t` (`a`) values (2)",
-	}
-	if len(h.queries) != len(want) {
-		t.Fatalf("expected queries %q, got %q", want, h.queries)
-	}
-	for i := range want {
-		if h.queries[i] != want[i] {
-			t.Fatalf("expected queries %q, got %q", want, h.queries)
-		}
-	}
-}
-
-// A deadlock raised by a replayed statement ends the re-opened transaction on
-// the session again, so it must not be retried inline (that retry would run in
-// autocommit). Instead the whole reconstruction restarts: a second `start
-// transaction` re-opens the tx before the recorded queries are replayed again.
-func TestExecDeadlockReplayReopensWhenReplayDeadlocks(t *testing.T) {
-	originalMax := MaxAttempts
-	MaxAttempts = 3
-	t.Cleanup(func() { MaxAttempts = originalMax })
-
-	// call 0: original insert deadlocks; call 1: first `start transaction`;
-	// call 2: replayed update deadlocks; the reconstruction restarts.
-	h := &recordingExecHandler{errors: []error{errTestDeadlock, nil, errTestDeadlock}}
-
-	db := &Database{}
-	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
-	if err != nil {
-		t.Fatalf("expected the replay restart + retry to recover, got %v", err)
-	}
-	want := []string{
-		"insert into `t` (`a`) values (2)",
-		"start transaction",
-		"update `t` set `a` = 1", // replay deadlocks
-		"start transaction",      // reconstruction restarts before replaying again
-		"update `t` set `a` = 1", // replay succeeds
-		"insert into `t` (`a`) values (2)",
-	}
-	if len(h.queries) != len(want) {
-		t.Fatalf("expected queries %q, got %q", want, h.queries)
-	}
-	for i := range want {
-		if h.queries[i] != want[i] {
-			t.Fatalf("expected queries %q, got %q", want, h.queries)
-		}
-	}
-}
-
-// If re-opening the transaction fails, the replay must not run — committing the
-// recorded queries in autocommit mode is exactly what the re-open prevents — so
-// the start-transaction error surfaces and no recorded query is replayed.
-func TestExecDeadlockReplayAbortsWhenReopenFails(t *testing.T) {
-	originalMax := MaxAttempts
-	MaxAttempts = 3
-	t.Cleanup(func() { MaxAttempts = originalMax })
-
-	reopenErr := errors.New("connection is dead")
-	// call 0 is the original statement (deadlock); call 1 is `start transaction`.
-	h := &recordingExecHandler{errors: []error{errTestDeadlock, reopenErr}}
-
-	db := &Database{}
-	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
-	if err == nil {
-		t.Fatal("expected the re-open failure to surface")
-	}
-	if !errors.Is(err, reopenErr) {
-		t.Fatalf("expected the start-transaction error, got %v", err)
-	}
-	want := []string{
-		"insert into `t` (`a`) values (2)",
-		"start transaction",
-	}
-	if len(h.queries) != len(want) {
-		t.Fatalf("expected no replay after a failed re-open, got %q", h.queries)
-	}
-	for i := range want {
-		if h.queries[i] != want[i] {
-			t.Fatalf("expected queries %q, got %q", want, h.queries)
-		}
-	}
-}
-
-// A non-deadlock failure during replay can't be recovered by re-opening and
-// replaying again, so it is terminal: the reconstruction stops and the error
-// surfaces instead of looping.
-func TestExecDeadlockReplayAbortsOnNonDeadlockReplayFailure(t *testing.T) {
-	originalMax := MaxAttempts
-	MaxAttempts = 3
-	t.Cleanup(func() { MaxAttempts = originalMax })
-
-	replayErr := errors.New("table is gone")
-	// call 0: original insert deadlocks; call 1: `start transaction`; call 2:
-	// replayed update fails with a non-deadlock, terminal error.
-	h := &recordingExecHandler{errors: []error{errTestDeadlock, nil, replayErr}}
-
-	db := &Database{}
-	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
-	if err == nil {
-		t.Fatal("expected the non-deadlock replay failure to surface")
-	}
-	if !errors.Is(err, replayErr) {
-		t.Fatalf("expected the replay error, got %v", err)
-	}
-	want := []string{
-		"insert into `t` (`a`) values (2)",
-		"start transaction",
-		"update `t` set `a` = 1", // replay fails terminally — no restart
-	}
-	if len(h.queries) != len(want) {
-		t.Fatalf("expected the replay to abort, got %q", h.queries)
-	}
-	for i := range want {
-		if h.queries[i] != want[i] {
-			t.Fatalf("expected queries %q, got %q", want, h.queries)
-		}
-	}
-}
-
-// When attempts are uncapped (MaxAttempts == 0), MaxExecutionTime must bound the
-// reconstruction loop so a persistently deadlocking replay can't spin forever.
-// With the budget already exhausted the deadlock surfaces before any replay.
-func TestExecDeadlockReplayBoundedByMaxExecutionTime(t *testing.T) {
-	originalMax := MaxAttempts
-	MaxAttempts = 0 // uncapped — only MaxExecutionTime can bound the loop
-	t.Cleanup(func() { MaxAttempts = originalMax })
-
-	h := &recordingExecHandler{errors: []error{errTestDeadlock}}
-
-	// any elapsed time exceeds a 1ns budget, so the loop aborts on its first
-	// pass before re-opening the transaction.
-	db := &Database{MaxExecutionTime: time.Nanosecond}
-	_, err := db.exec(h, context.Background(), newDeadlockTestTx(), true, "insert into `t` (`a`) values (2)")
-	if err == nil {
-		t.Fatal("expected the deadlock error to surface")
-	}
-	var mysqlErr *stdMysql.MySQLError
-	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1213 {
-		t.Fatalf("expected error 1213, got %v", err)
-	}
-	if len(h.queries) != 1 {
-		t.Fatalf("expected the time budget to abort before any replay, got %q", h.queries)
+	if len(h.queries) != 2 {
+		t.Fatalf("expected the statement to run twice (deadlock then retry), got %q", h.queries)
 	}
 }

--- a/execution_time_test.go
+++ b/execution_time_test.go
@@ -189,7 +189,7 @@ func TestExec_RespectsDBMaxExecutionTime(t *testing.T) {
 	db := &Database{MaxExecutionTime: time.Nanosecond}
 
 	start := time.Now()
-	_, err := db.exec(h, context.Background(), nil, true, "SELECT 1")
+	_, err := db.exec(h, context.Background(), nil, "SELECT 1")
 	elapsed := time.Since(start)
 
 	require.Error(t, err)

--- a/insert.go
+++ b/insert.go
@@ -338,7 +338,7 @@ DUPE_KEY_SEARCH:
 
 		// One string copy per chunk (not per row) — amortized across thousands
 		// of rows, negligible next to the row-build savings.
-		result, err := in.db.exec(in.conn, ctx, in.tx, true, string(insertBuf))
+		result, err := in.db.exec(in.conn, ctx, in.tx, string(insertBuf))
 		if err != nil {
 			return err
 		}

--- a/tx.go
+++ b/tx.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 )
 
@@ -17,12 +16,7 @@ type Tx struct {
 	Tx   *sql.Tx
 	Time time.Time
 
-	updates *struct {
-		sync.RWMutex
-		queries []string
-	}
-
-	PostCommitHooks    []func() error
+	PostCommitHooks   []func() error
 	PostRollbackHooks []func()
 }
 
@@ -36,11 +30,6 @@ func (db *Database) beginTx(conn *sql.DB, ctx context.Context) (*Tx, txCancelFun
 		db:   db,
 		Tx:   t,
 		Time: time.Now(),
-
-		updates: &struct {
-			sync.RWMutex
-			queries []string
-		}{queries: make([]string, 0)},
 	}
 
 	db.callLog(LogDetail{
@@ -152,7 +141,7 @@ func (tx *Tx) InsertContext(ctx context.Context, insert string, source any) erro
 
 // ExecContextResult executes a query and nothing more
 func (tx *Tx) ExecContextResult(ctx context.Context, query string, params ...any) (sql.Result, error) {
-	return tx.db.exec(tx.Tx, ctx, tx, true, query, params...)
+	return tx.db.exec(tx.Tx, ctx, tx, query, params...)
 }
 
 // ExecContext executes a query and nothing more

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,9 +1,12 @@
 package mysql
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	stdMysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,6 +146,67 @@ func TestPostRollbackHooksNotRunWhenAlreadyCommitted(t *testing.T) {
 	err = cancel()
 	require.NoError(t, err)
 	require.False(t, called, "PostRollbackHook should not run when tx was already committed")
+}
+
+// db.ExecResult runs on the writes pool outside any transaction; the result is
+// returned to the caller.
+func TestDatabaseExecResult(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectExec("insert into `t`").WillReturnResult(sqlmock.NewResult(7, 1))
+
+	res, err := db.ExecResult("insert into `t` (`a`) values (1)")
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	require.Equal(t, int64(7), id)
+}
+
+// tx.ExecResult runs the statement on the transaction's connection; the work is
+// only durable once the caller commits.
+func TestTxExecResult(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("update `t`").WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	tx, cancel, err := db.BeginTx()
+	require.NoError(t, err)
+	defer cancel()
+
+	res, err := tx.ExecResult("update `t` set `a` = 1")
+	require.NoError(t, err)
+	n, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(2), n)
+
+	require.NoError(t, tx.Commit())
+}
+
+// A deadlock (1213) inside an explicit transaction must surface to the caller
+// unchanged — no inline retry and no autocommit replay (either would appear
+// here as an unexpected second Exec or a `start transaction`, which sqlmock
+// would reject). The caller then rolls back the dead transaction and is free to
+// restart it from Begin (#167).
+func TestTxExecDeadlockSurfacesForCallerRetry(t *testing.T) {
+	db, mock, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("insert into `t`").WillReturnError(errTestDeadlock)
+	mock.ExpectRollback()
+
+	tx, cancel, err := db.BeginTx()
+	require.NoError(t, err)
+	defer cancel() // rolls back the deadlocked transaction
+
+	err = tx.Exec("insert into `t` (`a`) values (1)")
+	require.Error(t, err)
+	var mysqlErr *stdMysql.MySQLError
+	require.True(t, errors.As(err, &mysqlErr) && mysqlErr.Number == 1213, "want error 1213, got %v", err)
 }
 
 func TestPostRollbackHooksMultiple(t *testing.T) {

--- a/upsert.go
+++ b/upsert.go
@@ -230,7 +230,7 @@ func (in *Inserter) upsert(ctx context.Context, query string, uniqueColumns, upd
 			}
 
 			if len(updateColumns) != 0 {
-				res, err := in.db.exec(in.conn, ctx, in.tx, true, q, r)
+				res, err := in.db.exec(in.conn, ctx, in.tx, q, r)
 				if err != nil {
 					return Wrap(fmt.Errorf("failed to update: %w", err), query, q, r)
 				}


### PR DESCRIPTION
Fixes #167.

## Problem

A 1213 deadlock rolls back **and ends** the whole transaction on the session, leaving the connection in autocommit mode. cool-mysql replayed the transaction's recorded writes to retry transparently — but that can't preserve atomicity:

- **Original behavior:** the replay ran in autocommit, committing each recorded write durably **outside** the caller's transaction. If the caller later rolled back (or relied on the tx for dedup/atomicity), those replayed rows survived as phantom committed rows.
- **#166 (current master):** re-opened the tx via a raw `start transaction` on the same `*sql.Tx` and replayed inside it. This relies on **unsupported** transaction-control SQL through a `database/sql.Tx`, and still can't preserve true atomicity — only `Exec` writes are recorded, so non-recorded `Select … FOR UPDATE` locks and read-snapshot state are never replayed.

## Fix — Option 1 (the issue's recommended "safe, minimal fix")

On a deadlock inside an explicit transaction, return `backoff.Permanent(err)` so the retry loop stops and the clean 1213 surfaces to the caller. `unwrapBackoffPermanent` strips the internal wrapper so a caller's own `backoff.Retry` isn't hijacked. The caller restarts the **whole** transaction from `Begin` — the only way to restore atomicity, including read-locks and snapshot consistency.

Autocommit (non-tx) deadlocks still retry transparently, exactly as before.

The now-dead replay machinery is removed: `replayTx`, the `tx.updates` query recording, and the vestigial `newQuery` `exec` parameter (net **−169 lines**).

## Behavior change

Callers relying on **transparent mid-transaction** deadlock retry must now wrap their `Begin → … → Commit` in their own retry loop. This is the standard, correct pattern for deadlock handling and supersedes the replay approach from #165/#166 — worth calling out in the next release tag.

## Verification

- `go vet ./...` — clean
- `go test -coverprofile=… -covermode=atomic ./...` (and `-race`) — pass
- `golangci-lint run --timeout=3m` — 0 issues
- 100% patch coverage of all changed lines (new tx-deadlock-surfaces tests at both the `exec` and public `Exec`/tx-API levels)
- GPT-5.5 code review — clean, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)